### PR TITLE
[codex] Run Mist and MySQL in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,8 @@ RUN --mount=type=cache,target=/root/.npm \
 
 # Copy build output from builder stage
 COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/tools ./tools
+COPY --from=builder /app/deploy/windows/database ./deploy/windows/database
 COPY --from=builder /app/node_modules/.pnpm ./node_modules/.pnpm
 
 # Expose ports

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN --mount=type=cache,target=/root/.npm \
 
 # Copy source and build
 COPY . .
-RUN pnpm run build
+RUN pnpm run build:docker
 
 # Stage 2: Production - Run with Node.js
 FROM node:24-alpine
@@ -56,3 +56,4 @@ COPY docker-start.sh ./
 RUN chmod +x docker-start.sh
 
 ENTRYPOINT ["./docker-entrypoint.sh"]
+CMD ["node", "dist/apps/mist/main.js"]

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ mist/
 
 ### 方式一：Docker 部署（推荐用于生产环境）
 
+Windows API 机器的正式部署以 `mist-deploy` 仓库为入口：Docker Desktop
+运行 `mysql`、`mist-backend`、`chan-api`，`mist-tdx-datasource` 继续作为
+WinSW 服务运行在 Windows Host。详细说明见
+[`deploy/docker/README-Windows-Docker.md`](deploy/docker/README-Windows-Docker.md)。
+
 #### 快速启动
 
 ```bash

--- a/apps/chan/src/chan-app.module.spec.ts
+++ b/apps/chan/src/chan-app.module.spec.ts
@@ -1,0 +1,15 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('ChanAppModule', () => {
+  const source = fs.readFileSync(
+    path.join(__dirname, 'chan-app.module.ts'),
+    'utf8',
+  );
+
+  it('registers a TypeORM root connection for imported repository modules', () => {
+    expect(source).toContain('TypeOrmModule.forRootAsync');
+    expect(source).toContain('ConfigService');
+    expect(source).toContain('SecuritySourceConfig');
+  });
+});

--- a/apps/chan/src/chan-app.module.ts
+++ b/apps/chan/src/chan-app.module.ts
@@ -1,9 +1,18 @@
 import { Module } from '@nestjs/common';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { chanEnvSchema } from '@app/config';
 import { ChanModule } from '../../mist/src/chan/chan.module';
 import * as path from 'path';
 import { HealthController } from './health.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import {
+  K,
+  KExtensionEf,
+  KExtensionMqmt,
+  KExtensionTdx,
+  Security,
+  SecuritySourceConfig,
+} from '@app/shared-data';
 
 @Module({
   imports: [
@@ -21,6 +30,34 @@ import { HealthController } from './health.controller';
         allowUnknown: true,
         abortEarly: false,
       },
+    }),
+    TypeOrmModule.forRootAsync({
+      useFactory(configService: ConfigService) {
+        return {
+          type: 'mysql',
+          host: configService.get('mysql_server_host'),
+          port: configService.get('mysql_server_port'),
+          username: configService.get('mysql_server_username'),
+          password: configService.get('mysql_server_password'),
+          database: configService.get('mysql_server_database'),
+          synchronize: configService.get('NODE_ENV') !== 'production',
+          logging: configService.get('NODE_ENV') !== 'production',
+          entities: [
+            K,
+            KExtensionEf,
+            KExtensionTdx,
+            KExtensionMqmt,
+            Security,
+            SecuritySourceConfig,
+          ],
+          poolSize: 10,
+          connectorPackage: 'mysql2',
+          extra: {
+            authPlugins: 'sha256_password',
+          },
+        };
+      },
+      inject: [ConfigService],
     }),
     ChanModule,
   ],

--- a/apps/chan/src/chan-app.module.ts
+++ b/apps/chan/src/chan-app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { chanEnvSchema } from '@app/config';
 import { ChanModule } from '../../mist/src/chan/chan.module';
 import * as path from 'path';
+import { HealthController } from './health.controller';
 
 @Module({
   imports: [
@@ -23,5 +24,6 @@ import * as path from 'path';
     }),
     ChanModule,
   ],
+  controllers: [HealthController],
 })
 export class ChanAppModule {}

--- a/apps/chan/src/health.controller.spec.ts
+++ b/apps/chan/src/health.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HealthController } from './health.controller';
+
+describe('HealthController', () => {
+  let controller: HealthController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [HealthController],
+    }).compile();
+
+    controller = module.get<HealthController>(HealthController);
+  });
+
+  it('returns a stable health response', () => {
+    expect(controller.getHello()).toBe('Hello World!');
+  });
+});

--- a/apps/chan/src/health.controller.ts
+++ b/apps/chan/src/health.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('app')
+export class HealthController {
+  @Get('hello')
+  getHello(): string {
+    return 'Hello World!';
+  }
+}

--- a/apps/chan/src/types/body-parser.d.ts
+++ b/apps/chan/src/types/body-parser.d.ts
@@ -1,0 +1,4 @@
+declare module 'body-parser' {
+  export function json(options?: Record<string, unknown>): any;
+  export function urlencoded(options?: Record<string, unknown>): any;
+}

--- a/deploy/docker/README-Windows-Docker.md
+++ b/deploy/docker/README-Windows-Docker.md
@@ -21,6 +21,25 @@ Mac / LLM machine
   - MIST_API_BASE_URL=http://<windows-lan-ip>:8001
 ```
 
+## Default Windows Layout
+
+```text
+E:\quant\MistDocker
+  compose.yaml
+  .env
+  mysql-data\
+  backups\
+  diagnostics\
+
+F:\quant\MistAPI\datasource
+  .env
+  logs\
+  services\mist-tdx-datasource\
+```
+
+`E:\quant\MistDocker\.env` is the Docker environment file. It must contain
+`MYSQL_DATA_DIR=E:\quant\MistDocker\mysql-data` for the MySQL bind mount.
+
 `apps/schedule`, `apps/saya`, and `apps/mcp-server` are not part of the default
 production Docker stack. `apps/schedule` needs a separate production ownership
 decision before it is deployed.

--- a/deploy/docker/README-Windows-Docker.md
+++ b/deploy/docker/README-Windows-Docker.md
@@ -1,0 +1,88 @@
+# Mist Windows Docker Deployment
+
+This is the production deployment shape for the Windows API machine after
+`run-mist-mysql-in-docker`.
+
+## Topology
+
+```text
+Windows API machine
+  Docker Desktop
+    - mysql
+    - mist-backend on 0.0.0.0:8001
+    - chan-api on 0.0.0.0:8008
+    - mist-migrate one-shot migration runner
+
+  Windows host
+    - mist-tdx-datasource WinSW service on 127.0.0.1:9001
+    - TDX Desktop, SDK files, login state, and strategy cleanup
+
+Mac / LLM machine
+  - MIST_API_BASE_URL=http://<windows-lan-ip>:8001
+```
+
+`apps/schedule`, `apps/saya`, and `apps/mcp-server` are not part of the default
+production Docker stack. `apps/schedule` needs a separate production ownership
+decision before it is deployed.
+
+## Runtime Contract
+
+The Docker image contains both application entrypoints:
+
+```text
+dist/apps/mist/main.js
+dist/apps/chan/main.js
+```
+
+The default image command starts `apps/mist`:
+
+```text
+node dist/apps/mist/main.js
+```
+
+`chan-api` overrides the command in Compose:
+
+```text
+node dist/apps/chan/main.js
+```
+
+Database migrations are bundled with the Mist image and run explicitly through:
+
+```text
+node tools/run-migrations.mjs
+```
+
+Production deployments must not rely on TypeORM `synchronize`; `apps/mist`
+already disables synchronize when `NODE_ENV=production`.
+
+## Datasource Boundary
+
+The datasource remains outside Docker as the WinSW-managed Windows service
+`mist-tdx-datasource`. Containers reach it through:
+
+```text
+TDX_BASE_URL=http://host.docker.internal:9001
+```
+
+If container-to-host health checks fail, first verify the datasource bind
+address and Windows firewall. Do not add a datasource container in this change.
+
+## Deployment Owner
+
+The deployable Compose file, machine-local `.env`, backup, rollback, health
+check, diagnostics, and GitHub Actions workflow live in `mist-deploy`.
+
+Normal production deployment is:
+
+```powershell
+.\scripts\deploy-docker-appliance.ps1 -ImageTag <tag> -PreviousImageTag <old-tag>
+```
+
+The GitHub Actions workflow is:
+
+```text
+Deploy Windows Docker Appliance
+```
+
+Use a release tag or commit SHA for production. Use `latest` only for an
+intentional fast-forward deploy.

--- a/docs/superpowers/plans/2026-06-28-run-mist-mysql-in-docker.md
+++ b/docs/superpowers/plans/2026-06-28-run-mist-mysql-in-docker.md
@@ -20,14 +20,13 @@
 
 ## Locked Defaults For First Implementation
 
-- Docker root: `E:\MistDocker`
+- Docker root: `E:\quant\MistDocker`
 - Datasource root: `F:\quant\MistAPI\datasource`
 - Backend port: `8001`
 - Chan port: `8008`
 - Datasource URL inside containers: `http://host.docker.internal:9001`
-- MySQL persistence: Docker named volume `mist-mysql-data`
-- MySQL backups and diagnostics: files under `E:\MistDocker\backups` and `E:\MistDocker\diagnostics`
-- Optional future data-path override: support a bind mount such as `E:\MistDocker\mysql-data`, but do not make it the default until Windows Docker Desktop performance and file-lock behavior are verified on the target machine.
+- MySQL persistence: bind mount `MYSQL_DATA_DIR=E:\quant\MistDocker\mysql-data`
+- MySQL backups and diagnostics: files under `E:\quant\MistDocker\backups` and `E:\quant\MistDocker\diagnostics`
 
 ## Repository Boundaries
 
@@ -191,7 +190,7 @@
     - `mist-backend` publishes `8001`.
     - `chan-api` publishes `8008`.
     - Both app services set `TDX_BASE_URL=http://host.docker.internal:9001`.
-    - `mysql` uses persistent volume `mist-mysql-data`.
+    - `mysql` uses `MYSQL_DATA_DIR` as a bind mount for `/var/lib/mysql`.
   - Test command on Windows:
     ```powershell
     powershell -ExecutionPolicy Bypass -File .\scripts\test-docker-compose-config.ps1
@@ -228,6 +227,7 @@
     - `MYSQL_DATABASE=mist`
     - `MYSQL_USER=mist`
     - `MYSQL_PASSWORD=change-me-app`
+    - `MYSQL_DATA_DIR=E:\quant\MistDocker\mysql-data`
     - `MIST_BACKEND_PORT=8001`
     - `CHAN_API_PORT=8008`
     - `TDX_BASE_URL=http://host.docker.internal:9001`
@@ -249,10 +249,10 @@
     - Create `scripts/deploy-docker-appliance.ps1`
     - Create `scripts/test-deploy-docker-appliance.ps1`
   - Test coverage:
-    - Default `DockerRoot` is `E:\MistDocker`.
+    - Default `DockerRoot` is `E:\quant\MistDocker`.
     - Default `DatasourceRoot` is `F:\quant\MistAPI\datasource`.
     - Script preserves existing `.env`.
-    - Script creates `backups` and `diagnostics` under `DockerRoot`.
+    - Script creates `mysql-data`, `backups`, and `diagnostics` under `DockerRoot`.
     - Script never installs or deletes `mist-tdx-datasource`.
     - Script can update `MIST_IMAGE_TAG` in the Docker `.env` file.
     - Script has a rollback path that restores the previous image tag.
@@ -263,7 +263,7 @@
 
 - [ ] Implement `scripts/deploy-docker-appliance.ps1`.
   - Parameters:
-    - `DockerRoot = "E:\MistDocker"`
+    - `DockerRoot = "E:\quant\MistDocker"`
     - `DatasourceRoot = "F:\quant\MistAPI\datasource"`
     - `Image = "ghcr.io/mist-trade/mist"`
     - `ImageTag = "latest"`
@@ -275,10 +275,10 @@
     - `LoadOnly`
   - Flow:
     1. Assert Docker CLI and Docker Compose are usable.
-    2. Create Docker root, backup root, diagnostics root.
+    2. Create Docker root, MySQL data root, backup root, diagnostics root.
     3. Copy `docker/compose.yaml` to `DockerRoot\compose.yaml`.
     4. Copy `docker/.env.example` to `DockerRoot\.env` only when `.env` does not exist.
-    5. Update image variables in `.env` from parameters without overwriting secrets.
+    5. Update image variables and `MYSQL_DATA_DIR` in `.env` from parameters without overwriting secrets.
     6. Start MySQL only:
        ```powershell
        docker compose --env-file .env -f compose.yaml up -d mysql
@@ -303,7 +303,7 @@
   - Could live inside `deploy-docker-appliance.ps1` first; extract later only if it becomes bulky.
   - Output path:
     ```text
-    E:\MistDocker\backups\mist-YYYYMMDD-HHmmss.sql
+    E:\quant\MistDocker\backups\mist-YYYYMMDD-HHmmss.sql
     ```
   - Use `docker compose exec -T mysql mysqldump` against the app database.
   - Record the backup path in deployment output.
@@ -353,7 +353,7 @@
 
 - [ ] Implement `scripts/health-check-docker-appliance.ps1`.
   - Parameters:
-    - `DockerRoot = "E:\MistDocker"`
+    - `DockerRoot = "E:\quant\MistDocker"`
     - `DatasourceRoot = "F:\quant\MistAPI\datasource"`
     - `BackendHost = "127.0.0.1"`
     - `BackendPort = 8001`
@@ -390,7 +390,7 @@
     - Create `scripts/collect-docker-appliance-diagnostics.ps1`
     - Create `scripts/test-docker-appliance-diagnostics.ps1`
   - Assertions:
-    - Creates timestamped directory under `E:\MistDocker\diagnostics`.
+    - Creates timestamped directory under `E:\quant\MistDocker\diagnostics`.
     - Writes Docker version/info when available.
     - Writes Compose service status.
     - Writes recent logs for `mysql`, `mist-backend`, and `chan-api`.
@@ -427,7 +427,7 @@
 - [ ] Verification:
   ```powershell
   powershell -ExecutionPolicy Bypass -File .\scripts\test-docker-appliance-diagnostics.ps1
-  powershell -ExecutionPolicy Bypass -File .\scripts\collect-docker-appliance-diagnostics.ps1 -DockerRoot E:\MistDocker -DatasourceRoot F:\quant\MistAPI\datasource
+  powershell -ExecutionPolicy Bypass -File .\scripts\collect-docker-appliance-diagnostics.ps1 -DockerRoot E:\quant\MistDocker -DatasourceRoot F:\quant\MistAPI\datasource
   ```
 
 - [ ] Commit checkpoint after Phase 7.
@@ -492,9 +492,9 @@
   - Must include:
     - First-time setup:
       ```powershell
-      New-Item -ItemType Directory -Force E:\MistDocker
-      Copy-Item .\docker\.env.example E:\MistDocker\.env
-      notepad E:\MistDocker\.env
+      New-Item -ItemType Directory -Force E:\quant\MistDocker
+      Copy-Item .\docker\.env.example E:\quant\MistDocker\.env
+      notepad E:\quant\MistDocker\.env
       ```
     - Normal upgrade:
       ```powershell
@@ -511,7 +511,8 @@
          - Docker Desktop is running.
          - The self-hosted runner is online with labels: self-hosted, windows, mist-api.
          - `mist-tdx-datasource` WinSW service is running.
-         - `E:\MistDocker\.env` exists and contains machine-local MySQL secrets.
+         - `E:\quant\MistDocker\.env` exists and contains machine-local MySQL secrets.
+         - `E:\quant\MistDocker\mysql-data` is the intended MySQL bind directory.
          - `F:\quant\MistAPI\datasource` contains datasource `.env`, service files, and logs.
          - If the GHCR package is private, the deploy workflow has a read token secret such as `GHCR_READ_TOKEN`.
 
@@ -522,7 +523,7 @@
          - `image_repository`: `ghcr.io/mist-trade/mist`
          - `image_tag`: target image tag, for example `<git-sha>` or `v1.2.3`
          - `previous_image_tag`: the currently healthy tag, used for app rollback
-         - `docker_root`: `E:\MistDocker`
+         - `docker_root`: `E:\quant\MistDocker`
          - `datasource_root`: `F:\quant\MistAPI\datasource`
          - `skip_migration`: `false` for normal production deploys
          - `skip_backup`: `false` for normal production deploys
@@ -532,15 +533,16 @@
          - checkout `mist-deploy`
          - authenticate to GHCR when a read token is configured
          - call `scripts\deploy-docker-appliance.ps1`
-         - copy or reconcile `E:\MistDocker\compose.yaml`
-         - preserve `E:\MistDocker\.env`
+         - copy or reconcile `E:\quant\MistDocker\compose.yaml`
+         - preserve `E:\quant\MistDocker\.env`
+         - write `MYSQL_DATA_DIR=E:\quant\MistDocker\mysql-data`
          - pull the requested Mist image
          - start or verify Docker MySQL
-         - write a pre-migration backup under `E:\MistDocker\backups`
+         - write a pre-migration backup under `E:\quant\MistDocker\backups`
          - run `mist-migrate`
          - start `mist-backend` and `chan-api`
          - run hybrid health checks
-         - save diagnostics under `E:\MistDocker\diagnostics`
+         - save diagnostics under `E:\quant\MistDocker\diagnostics`
 
       6. Treat the deployment as successful only when:
          - GitHub Actions job is green.
@@ -618,13 +620,14 @@
   - Preconditions:
     - Docker Desktop running.
     - `mist-tdx-datasource` WinSW service running.
-    - `E:\MistDocker\.env` configured.
+    - `E:\quant\MistDocker\.env` configured.
+    - `E:\quant\MistDocker\mysql-data` available for the MySQL bind mount.
     - Datasource health reachable from the host.
   - Commands:
     ```powershell
     .\scripts\deploy-docker-appliance.ps1 -ImageTag <tag> -PreviousImageTag <old-tag>
     .\scripts\health-check-docker-appliance.ps1
-    docker compose --env-file E:\MistDocker\.env -f E:\MistDocker\compose.yaml exec mist-backend curl -fsS http://host.docker.internal:9001/health
+    docker compose --env-file E:\quant\MistDocker\.env -f E:\quant\MistDocker\compose.yaml exec mist-backend curl -fsS http://host.docker.internal:9001/health
     ```
   - Expected result:
     - MySQL healthy.
@@ -647,7 +650,7 @@
 ## Known Risks And Handling
 
 - If `host.docker.internal:9001` is not reachable from containers, first check datasource bind address and Windows firewall. Keep datasource local to the Windows API machine; do not expose it broadly on LAN without a concrete need.
-- If MySQL named volume is operationally inconvenient, add a documented `MYSQL_DATA_DIR` bind-mount mode and verify it on the target Windows Docker Desktop installation before making it the default.
+- Do not edit files under `E:\quant\MistDocker\mysql-data` while the MySQL container is running; use `mysqldump` backups and diagnostics for operational changes.
 - If migration fails, deployment must stop before reporting app health. Operators should use the pre-migration backup and diagnostics snapshot to decide whether to restore.
 - If `chan-api` later should become host-local only, change only the Compose port binding and health script input; keep the container service and health endpoint unchanged.
 - Do not add `apps/schedule` to Compose until there is a separate OpenSpec change defining its production data-source ownership.

--- a/docs/superpowers/plans/2026-06-28-run-mist-mysql-in-docker.md
+++ b/docs/superpowers/plans/2026-06-28-run-mist-mysql-in-docker.md
@@ -1,0 +1,653 @@
+# Run Mist and MySQL in Docker Implementation Plan
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (- [ ]) syntax for tracking.
+
+**Goal:** Implement the `run-mist-mysql-in-docker` OpenSpec change: on the Windows API machine, Docker Desktop runs MySQL, `apps/mist`, and `apps/chan`; the Windows-only TDX datasource remains the WinSW-managed host service.
+
+**Architecture:** The `mist` repository owns the Docker image runtime contract, production app commands, `chan` health endpoint, and migrations bundled with the image. The `mist-deploy` repository owns the Windows operator workflow: Compose files under the Docker root, machine-local `.env`, MySQL backup/restore, image update, migration execution, health checks, rollback, and diagnostics. Containers reach the host datasource through `TDX_BASE_URL=http://host.docker.internal:9001`; no datasource container is introduced.
+
+**Tech Stack:** NestJS 10, Node.js 24 Alpine, pnpm, Docker Desktop / Docker Compose, MySQL 8.4, PowerShell 5.1, GitHub Actions, GHCR, WinSW, OpenSpec.
+
+---
+
+## Current Findings
+
+- `mist/Dockerfile` builds TypeScript and exposes `8001`, `8008`, and `8009`, but has no production default `CMD`.
+- `mist/docker-compose.yml` is not the desired production stack: it starts `mist` plus `mcp-server`, uses a development MCP command, and has no MySQL container.
+- `apps/mist` already exposes `GET /app/hello`; `apps/chan` currently has no explicit health endpoint.
+- `deploy/windows/database/migrations` already contains idempotent SQL migrations and a PowerShell runner for the old appliance path.
+- `mist-deploy` is still centered on a Windows appliance zip, WinSW `MistBackend`, and portable MySQL.
+- `apps/schedule` remains excluded from this change until its production data-collection ownership is decided.
+
+## Locked Defaults For First Implementation
+
+- Docker root: `E:\MistDocker`
+- Datasource root: `F:\quant\MistAPI\datasource`
+- Backend port: `8001`
+- Chan port: `8008`
+- Datasource URL inside containers: `http://host.docker.internal:9001`
+- MySQL persistence: Docker named volume `mist-mysql-data`
+- MySQL backups and diagnostics: files under `E:\MistDocker\backups` and `E:\MistDocker\diagnostics`
+- Optional future data-path override: support a bind mount such as `E:\MistDocker\mysql-data`, but do not make it the default until Windows Docker Desktop performance and file-lock behavior are verified on the target machine.
+
+## Repository Boundaries
+
+- `mist`: image/runtime/app contract.
+- `mist-deploy`: Windows production orchestration.
+- `mist-datasource`: no first-pass code change. Only verify that the existing WinSW service can bind in a way Docker containers can reach.
+
+## Phase 1: Runtime Contract And Chan Health
+
+- [ ] Add a failing test for the `chan` health endpoint.
+  - Repository: `mist`
+  - Files:
+    - Create `apps/chan/src/health.controller.spec.ts`
+    - Create or modify `apps/chan/src/health.controller.ts`
+    - Modify `apps/chan/src/chan-app.module.ts`
+  - Test command:
+    ```bash
+    pnpm test -- apps/chan/src/health.controller.spec.ts
+    ```
+  - Expected first result: test fails because the controller does not exist.
+
+- [ ] Implement `GET /app/hello` for `apps/chan`.
+  - Use a tiny controller returning a stable string or object; do not require database or datasource connectivity.
+  - Keep the route aligned with `apps/mist` so health scripts can probe both services consistently.
+  - Verification:
+    ```bash
+    pnpm test -- apps/chan/src/health.controller.spec.ts
+    pnpm run build
+    ```
+  - Expected result: test and build pass.
+
+- [ ] Commit checkpoint after Phase 1.
+  - Suggested message:
+    ```bash
+    git add apps/chan/src
+    git commit -m "feat(chan): add production health endpoint"
+    ```
+
+## Phase 2: Mist Docker Image Runtime Contract
+
+- [ ] Add script-level checks for the production image contract.
+  - Repository: `mist`
+  - Files:
+    - Create `tools/test-docker-runtime.sh`
+  - Checks:
+    - `Dockerfile` has a production default `CMD` for `apps/mist`.
+    - Docker image can run `apps/chan` through `node dist/apps/chan/main.js`.
+    - Final image includes `dist/apps/mist/main.js` and `dist/apps/chan/main.js`.
+  - Test command:
+    ```bash
+    bash tools/test-docker-runtime.sh
+    ```
+  - Expected first result: fail on missing default `CMD`.
+
+- [ ] Update `Dockerfile` to support production `mist`, `chan`, and migration commands.
+  - Repository: `mist`
+  - Files:
+    - Modify `Dockerfile`
+    - Modify `package.json`
+    - Possibly modify `docker-entrypoint.sh` if command logging needs to avoid misleading "Mist Backend" output for `chan` and migration runs.
+  - Required behavior:
+    - Default command starts `apps/mist`:
+      ```dockerfile
+      CMD ["node", "dist/apps/mist/main.js"]
+      ```
+    - `chan-api` can override the command:
+      ```yaml
+      command: ["node", "dist/apps/chan/main.js"]
+      ```
+    - Migration service can override the command:
+      ```yaml
+      command: ["node", "tools/run-migrations.mjs"]
+      ```
+    - Do not use `pnpm run start:dev:*` anywhere in the production path.
+  - Verification:
+    ```bash
+    pnpm run build
+    bash tools/test-docker-runtime.sh
+    docker build -t mist:docker-runtime-test .
+    docker run --rm --entrypoint sh mist:docker-runtime-test -c "test -f dist/apps/mist/main.js && test -f dist/apps/chan/main.js"
+    ```
+  - Expected result: all commands exit `0`.
+
+- [ ] Commit checkpoint after Phase 2.
+  - Suggested message:
+    ```bash
+    git add Dockerfile docker-entrypoint.sh package.json tools/test-docker-runtime.sh
+    git commit -m "feat(docker): define production runtime commands"
+    ```
+
+## Phase 3: Migration Runner Bundled With Mist Release
+
+- [ ] Add a failing migration-runner test that uses a stub MySQL adapter.
+  - Repository: `mist`
+  - Files:
+    - Create `tools/run-migrations.mjs`
+    - Create `tools/test-run-migrations.mjs`
+  - Test command:
+    ```bash
+    node tools/test-run-migrations.mjs
+    ```
+  - Expected first result: fail until the runner can discover SQL files, create `schema_migrations`, skip applied files, and record new versions.
+
+- [ ] Implement `tools/run-migrations.mjs`.
+  - Inputs:
+    - `mysql_server_host`
+    - `mysql_server_port`
+    - `mysql_server_username`
+    - `mysql_server_password`
+    - `mysql_server_database`
+    - Optional `MIGRATION_DIR`, defaulting to `deploy/windows/database/migrations`
+  - Behavior:
+    - Validate database and migration identifiers.
+    - Create `schema_migrations`.
+    - Sort `*.sql` files by name.
+    - Skip already-applied migration versions.
+    - Apply one migration at a time using `mysql2/promise`.
+    - Insert the version only after the SQL succeeds.
+    - Fail with a clear message and non-zero exit code.
+  - Verification:
+    ```bash
+    node tools/test-run-migrations.mjs
+    pnpm run build
+    docker build -t mist:migration-runner-test .
+    docker run --rm --entrypoint sh mist:migration-runner-test -c "test -f tools/run-migrations.mjs && test -f deploy/windows/database/migrations/001_init_core_tables.sql"
+    bash tools/test-docker-runtime.sh
+    ```
+
+- [ ] Add an npm script for operator and Compose use.
+  - Repository: `mist`
+  - File:
+    - Modify `package.json`
+  - Script:
+    ```json
+    "db:migrate": "node tools/run-migrations.mjs"
+    ```
+  - Verification:
+    ```bash
+    pnpm run db:migrate
+    ```
+  - Expected result without MySQL: command fails clearly on connection, not on missing files or module load.
+
+- [ ] Commit checkpoint after Phase 3.
+  - Suggested message:
+    ```bash
+    git add package.json tools/run-migrations.mjs tools/test-run-migrations.mjs Dockerfile
+    git commit -m "feat(database): bundle docker migration runner"
+    ```
+
+## Phase 4: Production Docker Compose Assets
+
+- [ ] Add tests for the Docker appliance Compose template and env contract.
+  - Repository: `mist-deploy`
+  - Files:
+    - Create `scripts/test-docker-compose-config.ps1`
+    - Create `docker/compose.yaml`
+    - Create `docker/.env.example`
+  - Assertions:
+    - Services include `mysql`, `mist-migrate`, `mist-backend`, and `chan-api`.
+    - No `schedule`, `saya`, `mcp-server`, or datasource service is present.
+    - `mist-backend` publishes `8001`.
+    - `chan-api` publishes `8008`.
+    - Both app services set `TDX_BASE_URL=http://host.docker.internal:9001`.
+    - `mysql` uses persistent volume `mist-mysql-data`.
+  - Test command on Windows:
+    ```powershell
+    powershell -ExecutionPolicy Bypass -File .\scripts\test-docker-compose-config.ps1
+    ```
+  - Expected first result: fail until files exist.
+
+- [ ] Implement `mist-deploy/docker/compose.yaml`.
+  - Services:
+    - `mysql`
+    - `mist-migrate`
+    - `mist-backend`
+    - `chan-api`
+  - Required details:
+    - `mysql:8.4`
+    - `restart: unless-stopped` for long-running services.
+    - `depends_on` with MySQL health for app and migration services.
+    - `mist-migrate` is one-shot and not part of normal steady-state health.
+    - Use `MIST_IMAGE` and `MIST_IMAGE_TAG` from `.env`.
+    - Set `mysql_server_host=mysql`.
+    - Set `DEFAULT_DATA_SOURCE=tdx` for `mist-backend`.
+    - Set `TDX_BASE_URL=http://host.docker.internal:9001`.
+    - Publish `8001:8001` and `8008:8008`.
+  - Verification:
+    ```powershell
+    powershell -ExecutionPolicy Bypass -File .\scripts\test-docker-compose-config.ps1
+    docker compose --env-file .\docker\.env.example -f .\docker\compose.yaml config
+    ```
+
+- [ ] Implement `mist-deploy/docker/.env.example`.
+  - Required variables:
+    - `MIST_IMAGE=ghcr.io/mist-trade/mist`
+    - `MIST_IMAGE_TAG=latest`
+    - `MYSQL_ROOT_PASSWORD=change-me-root`
+    - `MYSQL_DATABASE=mist`
+    - `MYSQL_USER=mist`
+    - `MYSQL_PASSWORD=change-me-app`
+    - `MIST_BACKEND_PORT=8001`
+    - `CHAN_API_PORT=8008`
+    - `TDX_BASE_URL=http://host.docker.internal:9001`
+    - `DEFAULT_DATA_SOURCE=tdx`
+  - Do not put machine secrets in Git.
+
+- [ ] Commit checkpoint after Phase 4.
+  - Suggested message:
+    ```bash
+    git add docker/compose.yaml docker/.env.example scripts/test-docker-compose-config.ps1
+    git commit -m "feat(deploy): add docker appliance compose stack"
+    ```
+
+## Phase 5: Docker Deployment Script, Backup, Migration, Rollback
+
+- [ ] Add failing tests for deploy script helpers.
+  - Repository: `mist-deploy`
+  - Files:
+    - Create `scripts/deploy-docker-appliance.ps1`
+    - Create `scripts/test-deploy-docker-appliance.ps1`
+  - Test coverage:
+    - Default `DockerRoot` is `E:\MistDocker`.
+    - Default `DatasourceRoot` is `F:\quant\MistAPI\datasource`.
+    - Script preserves existing `.env`.
+    - Script creates `backups` and `diagnostics` under `DockerRoot`.
+    - Script never installs or deletes `mist-tdx-datasource`.
+    - Script can update `MIST_IMAGE_TAG` in the Docker `.env` file.
+    - Script has a rollback path that restores the previous image tag.
+  - Test command:
+    ```powershell
+    powershell -ExecutionPolicy Bypass -File .\scripts\test-deploy-docker-appliance.ps1
+    ```
+
+- [ ] Implement `scripts/deploy-docker-appliance.ps1`.
+  - Parameters:
+    - `DockerRoot = "E:\MistDocker"`
+    - `DatasourceRoot = "F:\quant\MistAPI\datasource"`
+    - `Image = "ghcr.io/mist-trade/mist"`
+    - `ImageTag = "latest"`
+    - `PreviousImageTag = ""`
+    - `SkipPull`
+    - `SkipMigration`
+    - `SkipBackup`
+    - `SkipHealthCheck`
+    - `LoadOnly`
+  - Flow:
+    1. Assert Docker CLI and Docker Compose are usable.
+    2. Create Docker root, backup root, diagnostics root.
+    3. Copy `docker/compose.yaml` to `DockerRoot\compose.yaml`.
+    4. Copy `docker/.env.example` to `DockerRoot\.env` only when `.env` does not exist.
+    5. Update image variables in `.env` from parameters without overwriting secrets.
+    6. Start MySQL only:
+       ```powershell
+       docker compose --env-file .env -f compose.yaml up -d mysql
+       ```
+    7. Wait for MySQL health.
+    8. Create a pre-migration backup unless `-SkipBackup`.
+    9. Run migrations unless `-SkipMigration`:
+       ```powershell
+       docker compose --env-file .env -f compose.yaml run --rm mist-migrate
+       ```
+    10. Start app services:
+       ```powershell
+       docker compose --env-file .env -f compose.yaml up -d mist-backend chan-api
+       ```
+    11. Run health checks unless `-SkipHealthCheck`.
+    12. Always save a short diagnostics snapshot on success or failure.
+  - Important constraint:
+    - Do not remove or replace `mist-tdx-datasource`; only read its status in health and diagnostics.
+
+- [ ] Implement Docker MySQL backup helper behavior.
+  - Repository: `mist-deploy`
+  - Could live inside `deploy-docker-appliance.ps1` first; extract later only if it becomes bulky.
+  - Output path:
+    ```text
+    E:\MistDocker\backups\mist-YYYYMMDD-HHmmss.sql
+    ```
+  - Use `docker compose exec -T mysql mysqldump` against the app database.
+  - Record the backup path in deployment output.
+  - Failed backup blocks migration unless `-SkipBackup` was explicitly set.
+
+- [ ] Implement rollback by image tag.
+  - Repository: `mist-deploy`
+  - Behavior:
+    - If deployment fails after `.env` image tag update and `PreviousImageTag` is provided, restore `MIST_IMAGE_TAG`.
+    - Run:
+      ```powershell
+      docker compose --env-file .env -f compose.yaml up -d mist-backend chan-api
+      ```
+    - Do not automatically roll back database state. Print backup path and manual restore instructions.
+
+- [ ] Verification:
+  ```powershell
+  powershell -ExecutionPolicy Bypass -File .\scripts\test-deploy-docker-appliance.ps1
+  powershell -ExecutionPolicy Bypass -File .\scripts\deploy-docker-appliance.ps1 -LoadOnly
+  ```
+
+- [ ] Commit checkpoint after Phase 5.
+  - Suggested message:
+    ```bash
+    git add scripts/deploy-docker-appliance.ps1 scripts/test-deploy-docker-appliance.ps1
+    git commit -m "feat(deploy): orchestrate docker appliance rollout"
+    ```
+
+## Phase 6: Hybrid Health Checks
+
+- [ ] Add failing tests for health-check script behavior.
+  - Repository: `mist-deploy`
+  - Files:
+    - Create `scripts/health-check-docker-appliance.ps1`
+    - Create `scripts/test-health-check-docker-appliance.ps1`
+  - Assertions:
+    - Checks Docker availability.
+    - Checks `docker compose ps` for `mysql`, `mist-backend`, and `chan-api`.
+    - Checks `http://127.0.0.1:8001/app/hello`.
+    - Checks `http://127.0.0.1:8008/app/hello`.
+    - Checks datasource via configured `TDX_BASE_URL`.
+    - Reads Docker root and datasource root independently.
+  - Test command:
+    ```powershell
+    powershell -ExecutionPolicy Bypass -File .\scripts\test-health-check-docker-appliance.ps1
+    ```
+
+- [ ] Implement `scripts/health-check-docker-appliance.ps1`.
+  - Parameters:
+    - `DockerRoot = "E:\MistDocker"`
+    - `DatasourceRoot = "F:\quant\MistAPI\datasource"`
+    - `BackendHost = "127.0.0.1"`
+    - `BackendPort = 8001`
+    - `ChanHost = "127.0.0.1"`
+    - `ChanPort = 8008`
+    - `DatasourceUrl = ""`
+    - `SkipDatasource`
+  - Behavior:
+    - Resolve `DatasourceUrl` from `.env` when not provided.
+    - Use `Invoke-WebRequest` or `Invoke-RestMethod` with short timeout.
+    - Fail non-zero on missing unhealthy required services.
+    - Print operator-ready endpoint summary, including Mac-side URL guidance:
+      ```text
+      MIST_API_BASE_URL=http://<windows-lan-ip>:8001
+      ```
+
+- [ ] Verification on a machine with Docker:
+  ```powershell
+  powershell -ExecutionPolicy Bypass -File .\scripts\health-check-docker-appliance.ps1 -SkipDatasource
+  ```
+
+- [ ] Commit checkpoint after Phase 6.
+  - Suggested message:
+    ```bash
+    git add scripts/health-check-docker-appliance.ps1 scripts/test-health-check-docker-appliance.ps1
+    git commit -m "feat(deploy): add hybrid docker health checks"
+    ```
+
+## Phase 7: Diagnostics And Logs
+
+- [ ] Add failing tests for diagnostics collection.
+  - Repository: `mist-deploy`
+  - Files:
+    - Create `scripts/collect-docker-appliance-diagnostics.ps1`
+    - Create `scripts/test-docker-appliance-diagnostics.ps1`
+  - Assertions:
+    - Creates timestamped directory under `E:\MistDocker\diagnostics`.
+    - Writes Docker version/info when available.
+    - Writes Compose service status.
+    - Writes recent logs for `mysql`, `mist-backend`, and `chan-api`.
+    - Writes `mist-tdx-datasource` service status.
+    - Copies recent datasource logs from `DatasourceRoot\logs`.
+    - Writes health-check output.
+    - Writes deployment metadata such as image tag, compose file path, and backup path when provided.
+
+- [ ] Implement `scripts/collect-docker-appliance-diagnostics.ps1`.
+  - Parameters:
+    - `DockerRoot`
+    - `DatasourceRoot`
+    - `Tail = 300`
+    - `DeploymentStatus = ""`
+    - `BackupPath = ""`
+  - Output examples:
+    ```text
+    diagnostics\20260628-153012\docker-version.txt
+    diagnostics\20260628-153012\compose-ps.txt
+    diagnostics\20260628-153012\logs-mysql.txt
+    diagnostics\20260628-153012\logs-mist-backend.txt
+    diagnostics\20260628-153012\logs-chan-api.txt
+    diagnostics\20260628-153012\datasource-service.txt
+    diagnostics\20260628-153012\datasource-logs\
+    diagnostics\20260628-153012\health-check.txt
+    diagnostics\20260628-153012\metadata.json
+    ```
+
+- [ ] Wire diagnostics into `deploy-docker-appliance.ps1`.
+  - On success: collect a short snapshot.
+  - On failure: collect a snapshot before throwing final error.
+  - Do not hide the original deployment error.
+
+- [ ] Verification:
+  ```powershell
+  powershell -ExecutionPolicy Bypass -File .\scripts\test-docker-appliance-diagnostics.ps1
+  powershell -ExecutionPolicy Bypass -File .\scripts\collect-docker-appliance-diagnostics.ps1 -DockerRoot E:\MistDocker -DatasourceRoot F:\quant\MistAPI\datasource
+  ```
+
+- [ ] Commit checkpoint after Phase 7.
+  - Suggested message:
+    ```bash
+    git add scripts/collect-docker-appliance-diagnostics.ps1 scripts/test-docker-appliance-diagnostics.ps1 scripts/deploy-docker-appliance.ps1
+    git commit -m "feat(deploy): collect hybrid appliance diagnostics"
+    ```
+
+## Phase 8: GitHub Actions Workflow
+
+- [ ] Add or replace tests for the Docker deployment workflow.
+  - Repository: `mist-deploy`
+  - Files:
+    - Modify or create `scripts/test-workflow-config.ps1`
+    - Create `.github/workflows/deploy-windows-docker-appliance.yml`
+  - Required assertions:
+    - Workflow runs on `[self-hosted, windows, mist-api]`.
+    - Inputs include `image_repository`, `image_tag`, `previous_image_tag`, `docker_root`, `datasource_root`, `skip_migration`, `skip_backup`, and `skip_health_check`.
+    - Workflow does not download a Windows appliance zip.
+    - Workflow invokes `scripts\deploy-docker-appliance.ps1`.
+    - Workflow uses Windows PowerShell (`shell: powershell`) for Windows runner compatibility.
+
+- [ ] Implement `.github/workflows/deploy-windows-docker-appliance.yml`.
+  - Keep the old appliance workflow only if needed for emergency legacy rollback; make the new Docker workflow the documented production path.
+  - Workflow steps:
+    1. Checkout `mist-deploy`.
+    2. Log selected image tag and roots.
+    3. Invoke `deploy-docker-appliance.ps1`.
+  - Do not require a build artifact run id; deployment consumes GHCR image tags.
+
+- [ ] Verification:
+  ```powershell
+  powershell -ExecutionPolicy Bypass -File .\scripts\test-workflow-config.ps1
+  ```
+
+- [ ] Commit checkpoint after Phase 8.
+  - Suggested message:
+    ```bash
+    git add .github/workflows/deploy-windows-docker-appliance.yml scripts/test-workflow-config.ps1
+    git commit -m "feat(ci): deploy docker appliance from image tags"
+    ```
+
+## Phase 9: Documentation And Operator Runbook
+
+- [ ] Update `mist` Docker documentation.
+  - Repository: `mist`
+  - Files:
+    - Modify `README.md`
+    - Add or modify `deploy/docker/README-Windows-Docker.md` if a focused doc is clearer than expanding the main README.
+  - Must document:
+    - Docker production stack is `mysql`, `mist-backend`, `chan-api`.
+    - `schedule`, `saya`, and `mcp-server` are not deployed by default.
+    - Datasource remains WinSW on the Windows host.
+    - Containers use `TDX_BASE_URL=http://host.docker.internal:9001`.
+    - MySQL migrations are explicit and production does not use TypeORM `synchronize`.
+
+- [ ] Update `mist-deploy` runbook.
+  - Repository: `mist-deploy`
+  - Files:
+    - Modify `README.md`
+  - Must include:
+    - First-time setup:
+      ```powershell
+      New-Item -ItemType Directory -Force E:\MistDocker
+      Copy-Item .\docker\.env.example E:\MistDocker\.env
+      notepad E:\MistDocker\.env
+      ```
+    - Normal upgrade:
+      ```powershell
+      .\scripts\deploy-docker-appliance.ps1 -ImageTag <tag> -PreviousImageTag <old-tag>
+      ```
+    - Automated GitHub Actions deployment:
+      ```text
+      1. In the `mist` repository, confirm the target Docker image exists:
+         - master image: ghcr.io/mist-trade/mist:<git-sha>
+         - release image: ghcr.io/mist-trade/mist:<version-or-tag>
+         Use a release tag or commit SHA for production; use `latest` only for an intentional fast-forward deploy.
+
+      2. On the Windows API machine, confirm prerequisites before triggering deployment:
+         - Docker Desktop is running.
+         - The self-hosted runner is online with labels: self-hosted, windows, mist-api.
+         - `mist-tdx-datasource` WinSW service is running.
+         - `E:\MistDocker\.env` exists and contains machine-local MySQL secrets.
+         - `F:\quant\MistAPI\datasource` contains datasource `.env`, service files, and logs.
+         - If the GHCR package is private, the deploy workflow has a read token secret such as `GHCR_READ_TOKEN`.
+
+      3. In the `mist-deploy` repository, open GitHub Actions and run:
+         Workflow: `Deploy Windows Docker Appliance`
+
+      4. Fill workflow inputs:
+         - `image_repository`: `ghcr.io/mist-trade/mist`
+         - `image_tag`: target image tag, for example `<git-sha>` or `v1.2.3`
+         - `previous_image_tag`: the currently healthy tag, used for app rollback
+         - `docker_root`: `E:\MistDocker`
+         - `datasource_root`: `F:\quant\MistAPI\datasource`
+         - `skip_migration`: `false` for normal production deploys
+         - `skip_backup`: `false` for normal production deploys
+         - `skip_health_check`: `false` for normal production deploys
+
+      5. The workflow performs these actions on the Windows runner:
+         - checkout `mist-deploy`
+         - authenticate to GHCR when a read token is configured
+         - call `scripts\deploy-docker-appliance.ps1`
+         - copy or reconcile `E:\MistDocker\compose.yaml`
+         - preserve `E:\MistDocker\.env`
+         - pull the requested Mist image
+         - start or verify Docker MySQL
+         - write a pre-migration backup under `E:\MistDocker\backups`
+         - run `mist-migrate`
+         - start `mist-backend` and `chan-api`
+         - run hybrid health checks
+         - save diagnostics under `E:\MistDocker\diagnostics`
+
+      6. Treat the deployment as successful only when:
+         - GitHub Actions job is green.
+         - workflow output prints the MySQL backup path.
+         - workflow output prints the diagnostics snapshot path.
+         - `mist-backend` health succeeds on `http://127.0.0.1:8001/app/hello`.
+         - `chan-api` health succeeds on `http://127.0.0.1:8008/app/hello`.
+         - datasource health succeeds through `http://host.docker.internal:9001/health` from the container side.
+
+      7. If deployment fails:
+         - Open the diagnostics snapshot path printed by the workflow.
+         - Check `health-check.txt`, `compose-ps.txt`, and recent service logs first.
+         - If `previous_image_tag` was provided, app containers are rolled back to that tag when possible.
+         - Database migrations are not automatically rolled back; use the printed backup path for a manual restore decision.
+         - Do not reinstall or remove `mist-tdx-datasource` as part of Docker app rollback.
+      ```
+    - Health:
+      ```powershell
+      .\scripts\health-check-docker-appliance.ps1
+      ```
+    - Diagnostics:
+      ```powershell
+      .\scripts\collect-docker-appliance-diagnostics.ps1
+      ```
+    - Rollback and database restore limits.
+    - Mac-side smoke:
+      ```bash
+      curl http://<windows-lan-ip>:8001/app/hello
+      curl http://<windows-lan-ip>:8008/app/hello
+      ```
+
+- [ ] Update OpenSpec task checkboxes only after implementation is actually complete.
+  - Repository: `mist`
+  - File:
+    - `openspec/changes/run-mist-mysql-in-docker/tasks.md`
+  - Do not mark tasks complete during planning.
+
+- [ ] Verification:
+  ```bash
+  openspec validate run-mist-mysql-in-docker --strict
+  ```
+  Expected output:
+  ```text
+  Change 'run-mist-mysql-in-docker' is valid
+  ```
+
+- [ ] Commit checkpoint after Phase 9.
+  - Suggested message:
+    ```bash
+    git add README.md deploy/docker docs/superpowers/plans/2026-06-28-run-mist-mysql-in-docker.md openspec/changes/run-mist-mysql-in-docker/tasks.md
+    git commit -m "docs: document docker windows appliance deployment"
+    ```
+
+## Phase 10: End-To-End Verification
+
+- [ ] Local `mist` verification.
+  ```bash
+  pnpm test -- apps/chan/src/health.controller.spec.ts
+  node tools/test-run-migrations.mjs
+  bash tools/test-docker-runtime.sh
+  pnpm run build
+  docker build -t mist:e2e-docker-appliance .
+  ```
+
+- [ ] Local or Windows `mist-deploy` verification.
+  ```powershell
+  powershell -ExecutionPolicy Bypass -File .\scripts\test-docker-compose-config.ps1
+  powershell -ExecutionPolicy Bypass -File .\scripts\test-deploy-docker-appliance.ps1
+  powershell -ExecutionPolicy Bypass -File .\scripts\test-health-check-docker-appliance.ps1
+  powershell -ExecutionPolicy Bypass -File .\scripts\test-docker-appliance-diagnostics.ps1
+  powershell -ExecutionPolicy Bypass -File .\scripts\test-workflow-config.ps1
+  ```
+
+- [ ] Windows API machine smoke.
+  - Preconditions:
+    - Docker Desktop running.
+    - `mist-tdx-datasource` WinSW service running.
+    - `E:\MistDocker\.env` configured.
+    - Datasource health reachable from the host.
+  - Commands:
+    ```powershell
+    .\scripts\deploy-docker-appliance.ps1 -ImageTag <tag> -PreviousImageTag <old-tag>
+    .\scripts\health-check-docker-appliance.ps1
+    docker compose --env-file E:\MistDocker\.env -f E:\MistDocker\compose.yaml exec mist-backend curl -fsS http://host.docker.internal:9001/health
+    ```
+  - Expected result:
+    - MySQL healthy.
+    - Migrations succeed.
+    - `mist-backend` healthy on `8001`.
+    - `chan-api` healthy on `8008`.
+    - Container-to-host datasource health succeeds.
+
+- [ ] Mac-side smoke.
+  ```bash
+  curl http://<windows-lan-ip>:8001/app/hello
+  curl http://<windows-lan-ip>:8008/app/hello
+  ```
+
+- [ ] OpenSpec verification.
+  ```bash
+  openspec validate run-mist-mysql-in-docker --strict
+  ```
+
+## Known Risks And Handling
+
+- If `host.docker.internal:9001` is not reachable from containers, first check datasource bind address and Windows firewall. Keep datasource local to the Windows API machine; do not expose it broadly on LAN without a concrete need.
+- If MySQL named volume is operationally inconvenient, add a documented `MYSQL_DATA_DIR` bind-mount mode and verify it on the target Windows Docker Desktop installation before making it the default.
+- If migration fails, deployment must stop before reporting app health. Operators should use the pre-migration backup and diagnostics snapshot to decide whether to restore.
+- If `chan-api` later should become host-local only, change only the Compose port binding and health script input; keep the container service and health endpoint unchanged.
+- Do not add `apps/schedule` to Compose until there is a separate OpenSpec change defining its production data-source ownership.

--- a/openspec/changes/run-mist-mysql-in-docker/.openspec.yaml
+++ b/openspec/changes/run-mist-mysql-in-docker/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-27

--- a/openspec/changes/run-mist-mysql-in-docker/design.md
+++ b/openspec/changes/run-mist-mysql-in-docker/design.md
@@ -199,9 +199,10 @@ Rollback:
 - Leave the datasource WinSW service untouched unless datasource-specific
   deployment changed.
 
-## Open Questions
+## Resolved Questions
 
-- Should `chan-api` be exposed on LAN port `8008` immediately, or only on the
-  Windows host until a concrete external consumer needs it?
-- What exact health endpoint should `chan-api` expose if `/app/hello` remains
-  specific to `apps/mist`?
+- `chan-api` is exposed on LAN port `8008` in the first deployment so Mac-side
+  smoke and future consumers can verify it the same way as `mist-backend`.
+- `chan-api` uses `/app/hello` as the first production availability endpoint.
+  A more domain-specific endpoint can be added later without changing the
+  initial Docker deployment contract.

--- a/openspec/changes/run-mist-mysql-in-docker/design.md
+++ b/openspec/changes/run-mist-mysql-in-docker/design.md
@@ -1,0 +1,163 @@
+## Context
+
+The Windows API machine is expected to run continuously with Docker Desktop
+available. The datasource layer is low churn and tied to Windows desktop state:
+TDX Desktop, local SDK DLLs, login/session state, and strategy cleanup. The Mist
+backend changes more frequently and is already published as a Docker image, so
+the production deployment should move the high-churn backend services and MySQL
+state into Docker while keeping the host-only datasource service on WinSW.
+
+The target machine may store Docker deployment files on a different drive from
+the datasource installation. The initial default layout is:
+
+```text
+E:\MistDocker
+    compose.yaml
+    .env
+    backups\
+    diagnostics\
+
+F:\quant\MistAPI\datasource
+    .env
+    logs\
+    services\mist-tdx-datasource\
+```
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Run `apps/mist`, `apps/chan`, and MySQL through Docker Compose on the Windows
+  API machine.
+- Keep `mist-tdx-datasource` as a WinSW-managed Windows host service.
+- Reuse the Mist Docker image publishing path for frequent backend releases.
+- Keep the datasource deployment stable and independent from Mist backend image
+  updates.
+- Provide a deploy workflow that can pull images, run migrations, start
+  containers, check datasource/backend/chan health, and collect diagnostics.
+- Support independent Docker and datasource roots, such as Docker state on `E:`
+  and datasource state on `F:`.
+
+**Non-Goals:**
+
+- Containerizing TDX Desktop, TDX SDK files, QMT, or `mist-datasource` in the
+  first version.
+- Deploying `apps/schedule` in the default production Compose stack.
+- Deploying `apps/saya` or `apps/mcp-server` in the first Docker production
+  stack.
+- Introducing a centralized logging platform such as Loki, ELK, or Grafana in
+  the first version.
+- Replacing the normalized backend-to-datasource contract.
+
+## Decisions
+
+### Use a hybrid Docker plus WinSW topology
+
+Docker Compose owns `mysql`, `mist-backend`, and `chan-api`. WinSW owns
+`mist-tdx-datasource`. This keeps the high-churn backend easy to update through
+image tags while leaving the Windows-specific datasource close to its desktop
+and SDK dependencies.
+
+Alternative considered: containerize everything. That would make the deployment
+surface look uniform, but it would force TDX Desktop and local SDK behavior into
+a container boundary that is not appropriate for the current provider.
+
+### Do not deploy `apps/schedule` by default
+
+The first Compose stack includes `apps/mist` and `apps/chan` only. The current
+schedule app has cron jobs tied to direct `EastMoneyCollectionStrategy` usage,
+while the production data path is moving toward TDX via the datasource service.
+Deploying it before its production role is decided risks duplicated or
+misaligned collection behavior.
+
+Alternative considered: include schedule as a disabled Compose profile. That is
+reasonable later, but the first production stack should not imply a supported
+schedule role before the collection ownership is settled.
+
+### Use `host.docker.internal` for datasource access
+
+Containerized Mist services use:
+
+```text
+TDX_BASE_URL=http://host.docker.internal:9001
+```
+
+The datasource service remains configured and tested from the Windows host. The
+implementation must verify that the Docker containers can reach the datasource
+health endpoint. If binding to `127.0.0.1` is insufficient for Docker Desktop,
+the datasource host binding and Windows firewall rules must be adjusted without
+exposing the service outside the machine unnecessarily.
+
+### Put migrations under the Mist release path
+
+Database migrations should follow the Mist image/release that needs them.
+Deployment should run an explicit migration step, such as a one-shot
+`mist-migrate` Compose service or a deployment script that applies the bundled
+SQL migrations against the MySQL container. Production must not rely on TypeORM
+`synchronize`.
+
+Alternative considered: keep migrations only in `mist-deploy`. That creates
+drift risk because Mist code and database changes would need to be synchronized
+across repositories manually.
+
+### Keep logs native but collect diagnostics through one command
+
+Docker services continue writing to stdout/stderr and WinSW continues writing
+datasource logs to files. Instead of forcing all logs into one sink in the first
+version, `mist-deploy` should provide a diagnostics command that collects Docker
+state/logs, datasource service state/logs, health-check output, and deployment
+metadata into a timestamped directory.
+
+Alternative considered: add a centralized logging stack. That is too heavy for
+the first hybrid deployment and can be added later if service count or retention
+needs grow.
+
+## Risks / Trade-offs
+
+- Docker Desktop startup or WSL2 state blocks backend startup -> deployment
+  health checks must include Docker service status and `docker compose ps`.
+- Containers cannot reach the host datasource through `host.docker.internal` ->
+  add a container-side datasource health probe and document the required
+  datasource bind/firewall adjustment.
+- MySQL data stored in Docker is harder to inspect directly than portable MySQL
+  files -> provide explicit backup and restore commands using `mysqldump` and
+  keep backup files under the Docker root.
+- Logs are split between Docker and WinSW -> provide `collect-logs.ps1` or an
+  equivalent diagnostics command that captures both sides.
+- Schedule app behavior remains undecided -> exclude it from the default stack
+  until its data-source ownership is specified.
+
+## Migration Plan
+
+1. Add a production Dockerfile/CMD and Compose stack for `mist-backend`,
+   `chan-api`, and MySQL.
+2. Add environment templates for the Docker stack, including MySQL credentials,
+   `TDX_BASE_URL=http://host.docker.internal:9001`, image tag, and exposed
+   ports.
+3. Add a migration runner path that applies Mist database migrations to the
+   MySQL container before backend services are started or upgraded.
+4. Update `mist-deploy` to manage Docker root and datasource root separately.
+5. Update deployment flow to pull the requested Mist image tag, start MySQL,
+   run migrations, start `mist-backend` and `chan-api`, then run health checks.
+6. Add diagnostics collection for Docker services and the WinSW datasource.
+7. Validate on the Windows API machine with Docker Desktop running, datasource
+   WinSW running, and Mac-side checks against ports `8001` and `8008`.
+
+Rollback:
+
+- Roll back `mist-backend` and `chan-api` by restoring the previous image tag in
+  the Compose environment and running `docker compose up -d`.
+- Roll back database state only from an explicit backup; migrations that are not
+  reversible must require a pre-upgrade backup.
+- Leave the datasource WinSW service untouched unless datasource-specific
+  deployment changed.
+
+## Open Questions
+
+- Should MySQL persistence default to a Docker named volume or an explicit
+  `E:\MistDocker\mysql-data` bind mount? Named volume is usually safer for
+  Docker Desktop performance; bind mount is more visible for manual backups.
+- Should `chan-api` be exposed on LAN port `8008` immediately, or only on the
+  Windows host until a concrete external consumer needs it?
+- What exact health endpoint should `chan-api` expose if `/app/hello` remains
+  specific to `apps/mist`?

--- a/openspec/changes/run-mist-mysql-in-docker/design.md
+++ b/openspec/changes/run-mist-mysql-in-docker/design.md
@@ -124,6 +124,37 @@ Alternative considered: add a centralized logging stack. That is too heavy for
 the first hybrid deployment and can be added later if service count or retention
 needs grow.
 
+### Provide a local datasource operations entrypoint
+
+Operators need a Windows-local command for the host-only datasource service, not
+only a GitHub Actions workflow. `mist-deploy` should provide
+`scripts/manage-tdx-datasource.ps1` with `start`, `stop`, `restart`, and
+`status` actions. The GitHub Actions datasource workflow should call this script
+instead of duplicating PowerShell inline. The script owns datasource runtime
+preflight: `.env` resolution, `TDX_SDK_PATH`, `tqcenter.py`,
+`TPythClient.dll`, `mist_datasource.py`, native TDX HTTP port `17709`, WinSW
+service state, health polling, and recent log/XML diagnostics on failure.
+
+### Reuse the datasource runtime smoke suite
+
+The complete business smoke already lives in `mist-datasource` as
+`scripts/run-runtime-checks.ps1`. The Docker deployment should not reimplement
+those endpoint checks. `mist-deploy` should provide a wrapper that locates the
+deployed datasource script under `F:\quant\MistAPI\datasource` and forwards
+parameters for basic HTTP, WebSocket, finance/report, reference/instrument, and
+formula smoke modes. Default smoke should remain read-only and safe for routine
+deploy verification.
+
+### Add bounded retention for generated operational artifacts
+
+The first version should add simple file-system retention for generated
+artifacts under `E:\quant\MistDocker`: MySQL dumps under `backups` and
+diagnostic snapshots under `diagnostics`. Default retention should keep recent
+evidence while preventing unbounded disk growth: 14 days and at least 20 MySQL
+backup files, plus 14 days and at least 20 diagnostics directories. Datasource
+WinSW logs remain owned by the datasource service; diagnostics may copy recent
+snippets but should not delete datasource logs by default.
+
 ## Risks / Trade-offs
 
 - Docker Desktop startup or WSL2 state blocks backend startup -> deployment
@@ -153,7 +184,10 @@ needs grow.
 5. Update deployment flow to pull the requested Mist image tag, start MySQL,
    run migrations, start `mist-backend` and `chan-api`, then run health checks.
 6. Add diagnostics collection for Docker services and the WinSW datasource.
-7. Validate on the Windows API machine with Docker Desktop running, datasource
+7. Add local datasource service operations and a runtime smoke wrapper that
+   reuses the deployed `mist-datasource` smoke scripts.
+8. Add retention cleanup for Docker-root backups and diagnostics.
+9. Validate on the Windows API machine with Docker Desktop running, datasource
    WinSW running, and Mac-side checks against ports `8001` and `8008`.
 
 Rollback:

--- a/openspec/changes/run-mist-mysql-in-docker/design.md
+++ b/openspec/changes/run-mist-mysql-in-docker/design.md
@@ -11,9 +11,10 @@ The target machine may store Docker deployment files on a different drive from
 the datasource installation. The initial default layout is:
 
 ```text
-E:\MistDocker
+E:\quant\MistDocker
     compose.yaml
     .env
+    mysql-data\
     backups\
     diagnostics\
 
@@ -100,6 +101,17 @@ Alternative considered: keep migrations only in `mist-deploy`. That creates
 drift risk because Mist code and database changes would need to be synchronized
 across repositories manually.
 
+### Persist MySQL through an explicit host bind directory
+
+MySQL data is stored in `E:\quant\MistDocker\mysql-data` by default through
+the Compose `MYSQL_DATA_DIR` bind mount. This keeps the Docker deployment
+layout visible to the Windows operator and places data, backups, diagnostics,
+Compose, and `.env` under the same `E:\quant\MistDocker` root.
+
+Alternative considered: Docker named volume. That is a reasonable default for
+opaque Docker-managed storage, but this deployment favors simple Windows-side
+inspection and backup handoff.
+
 ### Keep logs native but collect diagnostics through one command
 
 Docker services continue writing to stdout/stderr and WinSW continues writing
@@ -119,9 +131,9 @@ needs grow.
 - Containers cannot reach the host datasource through `host.docker.internal` ->
   add a container-side datasource health probe and document the required
   datasource bind/firewall adjustment.
-- MySQL data stored in Docker is harder to inspect directly than portable MySQL
-  files -> provide explicit backup and restore commands using `mysqldump` and
-  keep backup files under the Docker root.
+- MySQL data is now visible under the Docker root, but manual file-level edits
+  are still unsafe while MySQL is running -> provide explicit backup and restore
+  commands using `mysqldump` and keep backup files under the Docker root.
 - Logs are split between Docker and WinSW -> provide `collect-logs.ps1` or an
   equivalent diagnostics command that captures both sides.
 - Schedule app behavior remains undecided -> exclude it from the default stack
@@ -132,6 +144,7 @@ needs grow.
 1. Add a production Dockerfile/CMD and Compose stack for `mist-backend`,
    `chan-api`, and MySQL.
 2. Add environment templates for the Docker stack, including MySQL credentials,
+   `MYSQL_DATA_DIR=E:\quant\MistDocker\mysql-data`,
    `TDX_BASE_URL=http://host.docker.internal:9001`, image tag, and exposed
    ports.
 3. Add a migration runner path that applies Mist database migrations to the
@@ -154,9 +167,6 @@ Rollback:
 
 ## Open Questions
 
-- Should MySQL persistence default to a Docker named volume or an explicit
-  `E:\MistDocker\mysql-data` bind mount? Named volume is usually safer for
-  Docker Desktop performance; bind mount is more visible for manual backups.
 - Should `chan-api` be exposed on LAN port `8008` immediately, or only on the
   Windows host until a concrete external consumer needs it?
 - What exact health endpoint should `chan-api` expose if `/app/hello` remains

--- a/openspec/changes/run-mist-mysql-in-docker/proposal.md
+++ b/openspec/changes/run-mist-mysql-in-docker/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+The current Windows API appliance packages `MistBackend` and portable MySQL as
+Windows-managed runtime components, which makes every frequent Mist backend
+iteration heavier than necessary. The intended production split is now clearer:
+`mist` and MySQL should run under Docker Desktop on the Windows API machine,
+while the low-churn Windows-only datasource bridge remains a WinSW service on
+the host.
+
+## What Changes
+
+- Add a production Docker Compose deployment path for `apps/mist`, `apps/chan`,
+  and MySQL on the Windows API machine.
+- Keep `mist-tdx-datasource` deployed on the Windows host through WinSW, with
+  TDX Desktop, SDK paths, login state, and strategy cleanup outside Docker.
+- Configure containerized Mist services to reach the host datasource through
+  `TDX_BASE_URL=http://host.docker.internal:9001`.
+- Replace the first-choice production path for `MistBackend` and MySQL from
+  appliance-local WinSW/portable runtime management to Docker image and Compose
+  management.
+- Do not deploy `apps/schedule` in the first Docker production compose because
+  its current behavior is still under review and appears tied to EastMoney
+  polling.
+- Add deployment diagnostics that collect Docker service state, Docker logs,
+  datasource WinSW state/logs, and health-check output in one place.
+- Keep rollback based on Docker image tags for Mist services and explicit MySQL
+  backups for database state.
+
+## Capabilities
+
+### New Capabilities
+
+- `windows-docker-appliance`: Defines the hybrid Windows production deployment
+  where Docker Desktop runs `mist`, `chan`, and MySQL, while WinSW keeps running
+  the host-only datasource adapter.
+
+### Modified Capabilities
+
+- None. The datasource contract remains the existing normalized backend-to-
+  datasource boundary; this change modifies production deployment shape rather
+  than product API behavior.
+
+## Impact
+
+- `mist` Dockerfile, production Compose configuration, image entrypoints, and
+  release workflow assumptions.
+- `mist-deploy` deployment scripts and documentation, moving from downloading a
+  Windows appliance zip to managing Docker Compose state plus the existing
+  datasource WinSW service.
+- MySQL persistence, migration, backup, restore, and health-check operations.
+- Operational logging and diagnostics across Docker services and WinSW-managed
+  datasource logs.

--- a/openspec/changes/run-mist-mysql-in-docker/specs/windows-docker-appliance/spec.md
+++ b/openspec/changes/run-mist-mysql-in-docker/specs/windows-docker-appliance/spec.md
@@ -1,0 +1,98 @@
+## ADDED Requirements
+
+### Requirement: Docker compose runs production Mist services
+The system SHALL provide a production Docker Compose deployment for the Windows
+API machine that runs MySQL, `apps/mist`, and `apps/chan`.
+
+#### Scenario: Production compose starts required services
+- **WHEN** the operator starts the production Docker Compose stack on the Windows API machine
+- **THEN** the stack starts MySQL, `mist-backend`, and `chan-api`
+- **AND** `mist-backend` exposes port `8001`
+- **AND** `chan-api` exposes port `8008`
+
+#### Scenario: Schedule is excluded from default production compose
+- **WHEN** the operator starts the default production Docker Compose stack
+- **THEN** `apps/schedule` is not started by default
+- **AND** no schedule container performs cron-based data collection
+
+### Requirement: Datasource remains a Windows host service
+The system SHALL keep the TDX datasource adapter outside Docker as the
+WinSW-managed `mist-tdx-datasource` Windows service.
+
+#### Scenario: Containers use host datasource URL
+- **WHEN** `mist-backend` or `chan-api` starts in Docker
+- **THEN** the service is configured with `TDX_BASE_URL=http://host.docker.internal:9001`
+- **AND** the service does not call TDX native HTTP or SDKs directly
+
+#### Scenario: Datasource service is not replaced by Docker
+- **WHEN** the Docker deployment is installed or upgraded
+- **THEN** the deployment does not install a datasource container
+- **AND** the deployment does not remove or replace the `mist-tdx-datasource` WinSW service
+
+### Requirement: Docker and datasource roots are independently configurable
+The system SHALL allow Docker deployment state and datasource service state to
+live under separate root directories.
+
+#### Scenario: Docker root and datasource root use different drives
+- **WHEN** the operator configures Docker root as `E:\MistDocker`
+- **AND** the operator configures datasource root as `F:\quant\MistAPI\datasource`
+- **THEN** deployment scripts use the Docker root for Compose files, Docker
+  environment, backups, and diagnostics
+- **AND** deployment scripts use the datasource root for datasource `.env`,
+  WinSW service files, and datasource logs
+
+### Requirement: MySQL state is persistent and backed up explicitly
+The system SHALL persist MySQL data across container restarts and provide an
+explicit backup path before upgrades that may change the database schema.
+
+#### Scenario: MySQL data survives container recreation
+- **WHEN** the MySQL container is recreated during a normal Mist deployment
+- **THEN** existing MySQL data remains available after the new container starts
+
+#### Scenario: Deployment creates pre-upgrade database backup
+- **WHEN** a deployment includes database migrations
+- **THEN** the deployment creates or requires a MySQL backup before applying the migrations
+- **AND** the backup location is recorded in the deployment output
+
+### Requirement: Database migrations follow the Mist release
+The system SHALL run Mist database migrations as an explicit deployment step
+before updated Mist application containers are considered healthy.
+
+#### Scenario: Deployment applies migrations before health check
+- **WHEN** the deployment updates the Mist image tag
+- **THEN** the deployment runs the configured migration step against the MySQL container
+- **AND** the deployment runs backend health checks only after migrations succeed
+
+#### Scenario: Failed migration blocks application rollout
+- **WHEN** the migration step fails
+- **THEN** the deployment does not report the Mist Docker stack as healthy
+- **AND** the deployment prints the migration log location
+
+### Requirement: Hybrid health checks cover Docker and WinSW components
+The system SHALL verify both Docker-managed services and the host-managed
+datasource service during deployment and operator health checks.
+
+#### Scenario: Health check validates full hybrid stack
+- **WHEN** the operator runs the production health check
+- **THEN** it checks Docker Compose service status for MySQL, `mist-backend`,
+  and `chan-api`
+- **AND** it checks `mist-backend` HTTP health on port `8001`
+- **AND** it checks `chan-api` HTTP availability on port `8008`
+- **AND** it checks the datasource health endpoint through the same URL used by
+  the containers
+
+### Requirement: Diagnostics collect Docker and datasource logs together
+The system SHALL provide a single diagnostics collection command that captures
+the relevant Docker and WinSW state into a timestamped diagnostics directory.
+
+#### Scenario: Operator collects diagnostics
+- **WHEN** the operator runs the diagnostics collection command
+- **THEN** the command writes Docker Compose status, Docker logs for MySQL,
+  `mist-backend`, and `chan-api`, datasource WinSW service status, datasource
+  logs, health-check output, and deployment metadata into one timestamped
+  directory
+
+#### Scenario: Deployment saves diagnostic snapshot
+- **WHEN** a deployment completes or fails
+- **THEN** the deployment saves a short diagnostic snapshot that includes recent
+  Docker logs and datasource service state

--- a/openspec/changes/run-mist-mysql-in-docker/specs/windows-docker-appliance/spec.md
+++ b/openspec/changes/run-mist-mysql-in-docker/specs/windows-docker-appliance/spec.md
@@ -97,3 +97,57 @@ the relevant Docker and WinSW state into a timestamped diagnostics directory.
 - **WHEN** a deployment completes or fails
 - **THEN** the deployment saves a short diagnostic snapshot that includes recent
   Docker logs and datasource service state
+
+### Requirement: Local datasource operations are scriptable
+The system SHALL provide a Windows-local datasource operations command that can
+start, stop, restart, and inspect the host `mist-tdx-datasource` service without
+requiring a GitHub Actions dispatch.
+
+#### Scenario: Operator restarts datasource locally
+- **WHEN** the operator runs the datasource operations script with action
+  `restart`
+- **THEN** the script validates datasource root, SDK path, `tqcenter.py`,
+  `TPythClient.dll`, strategy identity file, and native TDX HTTP port
+- **AND** the script restarts the `mist-tdx-datasource` WinSW service
+- **AND** the script waits for the configured datasource health endpoint
+
+#### Scenario: Datasource workflow reuses local script
+- **WHEN** the GitHub Actions datasource management workflow runs
+- **THEN** it calls the same datasource operations script used by local
+  operators
+- **AND** the workflow does not maintain a separate inline implementation of
+  datasource preflight, start, restart, and health logic
+
+### Requirement: Runtime smoke can exercise datasource business paths
+The system SHALL expose a deployment-side command for running the existing
+`mist-datasource` runtime smoke suite against the deployed datasource service.
+
+#### Scenario: Operator runs default runtime smoke
+- **WHEN** the operator runs the deployment-side datasource smoke wrapper
+- **THEN** it invokes the deployed datasource `scripts\run-runtime-checks.ps1`
+- **AND** it verifies datasource health, provider manifest, normalized bars,
+  snapshots, sectors, calendar/security paths, and WebSocket ping/pong
+
+#### Scenario: Operator runs deeper runtime smoke modes
+- **WHEN** the operator passes finance/report or reference/instrument smoke
+  switches
+- **THEN** the wrapper forwards those switches to `run-runtime-checks.ps1`
+- **AND** the wrapper keeps formula and live subscription-changing checks
+  opt-in rather than default
+
+### Requirement: Generated backups and diagnostics have retention cleanup
+The system SHALL provide bounded retention for generated MySQL backup dumps and
+Docker diagnostics snapshots under the Docker deployment root.
+
+#### Scenario: Deployment prunes old MySQL backups
+- **WHEN** the deployment creates a MySQL dump under the Docker backup path
+- **THEN** it removes backup files older than the configured retention days
+- **AND** it keeps at least the configured minimum count of newest backup files
+
+#### Scenario: Deployment prunes old diagnostics snapshots
+- **WHEN** the deployment writes diagnostics under the Docker diagnostics path
+- **THEN** it removes diagnostics directories older than the configured
+  retention days
+- **AND** it keeps at least the configured minimum count of newest diagnostics
+  directories
+- **AND** it does not delete datasource WinSW logs by default

--- a/openspec/changes/run-mist-mysql-in-docker/specs/windows-docker-appliance/spec.md
+++ b/openspec/changes/run-mist-mysql-in-docker/specs/windows-docker-appliance/spec.md
@@ -34,10 +34,10 @@ The system SHALL allow Docker deployment state and datasource service state to
 live under separate root directories.
 
 #### Scenario: Docker root and datasource root use different drives
-- **WHEN** the operator configures Docker root as `E:\MistDocker`
+- **WHEN** the operator configures Docker root as `E:\quant\MistDocker`
 - **AND** the operator configures datasource root as `F:\quant\MistAPI\datasource`
 - **THEN** deployment scripts use the Docker root for Compose files, Docker
-  environment, backups, and diagnostics
+  environment, MySQL data, backups, and diagnostics
 - **AND** deployment scripts use the datasource root for datasource `.env`,
   WinSW service files, and datasource logs
 
@@ -46,7 +46,8 @@ The system SHALL persist MySQL data across container restarts and provide an
 explicit backup path before upgrades that may change the database schema.
 
 #### Scenario: MySQL data survives container recreation
-- **WHEN** the MySQL container is recreated during a normal Mist deployment
+- **WHEN** the MySQL container is recreated during a normal Mist deployment with
+  `MYSQL_DATA_DIR=E:\quant\MistDocker\mysql-data`
 - **THEN** existing MySQL data remains available after the new container starts
 
 #### Scenario: Deployment creates pre-upgrade database backup

--- a/openspec/changes/run-mist-mysql-in-docker/tasks.md
+++ b/openspec/changes/run-mist-mysql-in-docker/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Confirm Runtime Contract
 
-- [ ] 1.1 Decide whether MySQL persistence defaults to a Docker named volume or `E:\MistDocker\mysql-data` bind mount.
-- [ ] 1.2 Confirm default Docker root path, datasource root path, backup path, and diagnostics path.
+- [ ] 1.1 Confirm MySQL persistence defaults to the `E:\quant\MistDocker\mysql-data` bind mount.
+- [ ] 1.2 Confirm default Docker root path, datasource root path, MySQL data path, backup path, and diagnostics path.
 - [ ] 1.3 Confirm whether `chan-api` should be exposed on LAN port `8008` or host-local only in the first deployment.
 - [ ] 1.4 Define the first production health endpoint for `chan-api`.
 
@@ -17,7 +17,7 @@
 
 - [ ] 3.1 Add a production Compose file for `mysql`, `mist-backend`, and `chan-api`.
 - [ ] 3.2 Add a Docker environment template with image tag, MySQL credentials, ports, `DEFAULT_DATA_SOURCE=tdx`, and `TDX_BASE_URL=http://host.docker.internal:9001`.
-- [ ] 3.3 Configure MySQL persistence according to the decision from task 1.1.
+- [ ] 3.3 Configure MySQL persistence with `MYSQL_DATA_DIR=E:\quant\MistDocker\mysql-data`.
 - [ ] 3.4 Add container restart policies suitable for the Windows API machine.
 - [ ] 3.5 Add a container-side datasource reachability probe for `host.docker.internal:9001`.
 

--- a/openspec/changes/run-mist-mysql-in-docker/tasks.md
+++ b/openspec/changes/run-mist-mysql-in-docker/tasks.md
@@ -1,72 +1,72 @@
 ## 1. Confirm Runtime Contract
 
-- [ ] 1.1 Confirm MySQL persistence defaults to the `E:\quant\MistDocker\mysql-data` bind mount.
-- [ ] 1.2 Confirm default Docker root path, datasource root path, MySQL data path, backup path, and diagnostics path.
-- [ ] 1.3 Confirm whether `chan-api` should be exposed on LAN port `8008` or host-local only in the first deployment.
-- [ ] 1.4 Define the first production health endpoint for `chan-api`.
+- [x] 1.1 Confirm MySQL persistence defaults to the `E:\quant\MistDocker\mysql-data` bind mount.
+- [x] 1.2 Confirm default Docker root path, datasource root path, MySQL data path, backup path, and diagnostics path.
+- [x] 1.3 Confirm whether `chan-api` should be exposed on LAN port `8008` or host-local only in the first deployment.
+- [x] 1.4 Define the first production health endpoint for `chan-api`.
 
 ## 2. Prepare Mist Docker Runtime
 
-- [ ] 2.1 Update the Mist Docker image so it has a production default command for `apps/mist`.
-- [ ] 2.2 Add a supported container command for `apps/chan`.
-- [ ] 2.3 Remove development commands from the production Compose path.
-- [ ] 2.4 Verify the Docker image includes compiled outputs for both `dist/apps/mist/main.js` and `dist/apps/chan/main.js`.
-- [ ] 2.5 Add focused tests or script checks that validate production Docker entrypoints.
+- [x] 2.1 Update the Mist Docker image so it has a production default command for `apps/mist`.
+- [x] 2.2 Add a supported container command for `apps/chan`.
+- [x] 2.3 Remove development commands from the production Compose path.
+- [x] 2.4 Verify the Docker image includes compiled outputs for both `dist/apps/mist/main.js` and `dist/apps/chan/main.js`.
+- [x] 2.5 Add focused tests or script checks that validate production Docker entrypoints.
 
 ## 3. Add Production Docker Compose Stack
 
-- [ ] 3.1 Add a production Compose file for `mysql`, `mist-backend`, and `chan-api`.
-- [ ] 3.2 Add a Docker environment template with image tag, MySQL credentials, ports, `DEFAULT_DATA_SOURCE=tdx`, and `TDX_BASE_URL=http://host.docker.internal:9001`.
-- [ ] 3.3 Configure MySQL persistence with `MYSQL_DATA_DIR=E:\quant\MistDocker\mysql-data`.
-- [ ] 3.4 Add container restart policies suitable for the Windows API machine.
-- [ ] 3.5 Add a container-side datasource reachability probe for `host.docker.internal:9001`.
+- [x] 3.1 Add a production Compose file for `mysql`, `mist-backend`, and `chan-api`.
+- [x] 3.2 Add a Docker environment template with image tag, MySQL credentials, ports, `DEFAULT_DATA_SOURCE=tdx`, and `TDX_BASE_URL=http://host.docker.internal:9001`.
+- [x] 3.3 Configure MySQL persistence with `MYSQL_DATA_DIR=E:\quant\MistDocker\mysql-data`.
+- [x] 3.4 Add container restart policies suitable for the Windows API machine.
+- [x] 3.5 Add a container-side datasource reachability probe for `host.docker.internal:9001`.
 
 ## 4. Add Database Migration And Backup Flow
 
-- [ ] 4.1 Decide the migration runner shape: one-shot Compose service or deployment script applying bundled SQL.
-- [ ] 4.2 Package Mist database migrations with the Mist release path used by Docker deployment.
-- [ ] 4.3 Add a migration command that runs against the MySQL container and records applied migrations.
-- [ ] 4.4 Add a pre-migration backup command using `mysqldump` to the configured backup path.
-- [ ] 4.5 Ensure deployment fails fast and prints migration logs when migrations fail.
-- [ ] 4.6 Add restore documentation and a manual restore script for MySQL backups.
+- [x] 4.1 Decide the migration runner shape: one-shot Compose service or deployment script applying bundled SQL.
+- [x] 4.2 Package Mist database migrations with the Mist release path used by Docker deployment.
+- [x] 4.3 Add a migration command that runs against the MySQL container and records applied migrations.
+- [x] 4.4 Add a pre-migration backup command using `mysqldump` to the configured backup path.
+- [x] 4.5 Ensure deployment fails fast and prints migration logs when migrations fail.
+- [x] 4.6 Add restore documentation and a manual restore script for MySQL backups.
 
 ## 5. Refactor mist-deploy For Hybrid Docker Deployment
 
-- [ ] 5.1 Add `DockerRoot` and `DatasourceRoot` configuration to the deploy workflow and scripts.
-- [ ] 5.2 Change the deploy flow from appliance zip extraction to Docker Compose pull/up orchestration.
-- [ ] 5.3 Preserve machine-local Docker `.env`, datasource `.env`, MySQL data, backups, and diagnostics.
-- [ ] 5.4 Keep datasource WinSW installation and update logic separate from normal Mist image deployments.
-- [ ] 5.5 Add explicit rollback support by restoring the previous Mist image tag and restarting Compose services.
-- [ ] 5.6 Update workflow tests for the new Docker deploy inputs and removed appliance zip assumptions.
+- [x] 5.1 Add `DockerRoot` and `DatasourceRoot` configuration to the deploy workflow and scripts.
+- [x] 5.2 Change the deploy flow from appliance zip extraction to Docker Compose pull/up orchestration.
+- [x] 5.3 Preserve machine-local Docker `.env`, datasource `.env`, MySQL data, backups, and diagnostics.
+- [x] 5.4 Keep datasource WinSW installation and update logic separate from normal Mist image deployments.
+- [x] 5.5 Add explicit rollback support by restoring the previous Mist image tag and restarting Compose services.
+- [x] 5.6 Update workflow tests for the new Docker deploy inputs and removed appliance zip assumptions.
 
 ## 6. Add Hybrid Health Checks
 
-- [ ] 6.1 Add health checks for Docker Desktop availability and Docker Compose service status.
-- [ ] 6.2 Add MySQL container connectivity and schema initialization checks.
-- [ ] 6.3 Add `mist-backend` HTTP health checks on port `8001`.
-- [ ] 6.4 Add `chan-api` HTTP health checks on port `8008` or the selected exposure mode.
-- [ ] 6.5 Add datasource health checks using the same URL configured for containerized Mist services.
-- [ ] 6.6 Add Mac-side smoke guidance for `MIST_API_BASE_URL=http://<windows-lan-ip>:8001`.
+- [x] 6.1 Add health checks for Docker Desktop availability and Docker Compose service status.
+- [x] 6.2 Add MySQL container connectivity and schema initialization checks.
+- [x] 6.3 Add `mist-backend` HTTP health checks on port `8001`.
+- [x] 6.4 Add `chan-api` HTTP health checks on port `8008` or the selected exposure mode.
+- [x] 6.5 Add datasource health checks using the same URL configured for containerized Mist services.
+- [x] 6.6 Add Mac-side smoke guidance for `MIST_API_BASE_URL=http://<windows-lan-ip>:8001`.
 
 ## 7. Add Diagnostics And Log Collection
 
-- [ ] 7.1 Add a diagnostics command that writes timestamped output under the Docker diagnostics path.
-- [ ] 7.2 Collect `docker compose ps` and recent Docker logs for MySQL, `mist-backend`, and `chan-api`.
-- [ ] 7.3 Collect datasource WinSW service status and recent datasource logs from `DatasourceRoot`.
-- [ ] 7.4 Collect health-check output and deployment metadata.
-- [ ] 7.5 Save a short diagnostic snapshot after every deployment success or failure.
+- [x] 7.1 Add a diagnostics command that writes timestamped output under the Docker diagnostics path.
+- [x] 7.2 Collect `docker compose ps` and recent Docker logs for MySQL, `mist-backend`, and `chan-api`.
+- [x] 7.3 Collect datasource WinSW service status and recent datasource logs from `DatasourceRoot`.
+- [x] 7.4 Collect health-check output and deployment metadata.
+- [x] 7.5 Save a short diagnostic snapshot after every deployment success or failure.
 
 ## 8. Documentation And Verification
 
-- [ ] 8.1 Document the hybrid topology and explain why datasource remains WinSW-managed.
-- [ ] 8.2 Document first-time setup for Docker Desktop, Docker root, datasource root, and local `.env` files.
-- [ ] 8.3 Document normal upgrade, rollback, backup, restore, and diagnostics procedures.
-- [ ] 8.4 Run OpenSpec validation for `run-mist-mysql-in-docker`.
-- [ ] 8.5 Run local script/parser tests for changed deployment scripts.
-- [ ] 8.6 Build and push a Mist Docker image containing `apps/mist` and `apps/chan`.
-- [ ] 8.7 Deploy on the Windows API machine with datasource WinSW already running.
-- [ ] 8.8 Verify container-to-host datasource connectivity from the Mist containers.
-- [ ] 8.9 Verify Mac can reach `http://<windows-lan-ip>:8001` and `http://<windows-lan-ip>:8008` when enabled.
+- [x] 8.1 Document the hybrid topology and explain why datasource remains WinSW-managed.
+- [x] 8.2 Document first-time setup for Docker Desktop, Docker root, datasource root, and local `.env` files.
+- [x] 8.3 Document normal upgrade, rollback, backup, restore, and diagnostics procedures.
+- [x] 8.4 Run OpenSpec validation for `run-mist-mysql-in-docker`.
+- [x] 8.5 Run local script/parser tests for changed deployment scripts.
+- [x] 8.6 Build and push a Mist Docker image containing `apps/mist` and `apps/chan`.
+- [x] 8.7 Deploy on the Windows API machine with datasource WinSW already running.
+- [x] 8.8 Verify container-to-host datasource connectivity from the Mist containers.
+- [x] 8.9 Verify Mac can reach `http://<windows-lan-ip>:8001` and `http://<windows-lan-ip>:8008` when enabled.
 
 ## 9. Add Local Datasource Operations, Runtime Smoke, And Retention
 

--- a/openspec/changes/run-mist-mysql-in-docker/tasks.md
+++ b/openspec/changes/run-mist-mysql-in-docker/tasks.md
@@ -67,3 +67,14 @@
 - [ ] 8.7 Deploy on the Windows API machine with datasource WinSW already running.
 - [ ] 8.8 Verify container-to-host datasource connectivity from the Mist containers.
 - [ ] 8.9 Verify Mac can reach `http://<windows-lan-ip>:8001` and `http://<windows-lan-ip>:8008` when enabled.
+
+## 9. Add Local Datasource Operations, Runtime Smoke, And Retention
+
+- [x] 9.1 Update OpenSpec design/spec/tasks for local datasource operations, runtime smoke reuse, and retention cleanup.
+- [x] 9.2 Add deployment-script tests for the datasource operations script, runtime smoke wrapper, workflow reuse, and retention defaults.
+- [x] 9.3 Add `scripts/manage-tdx-datasource.ps1` for local `start`, `stop`, `restart`, and `status` operations on `mist-tdx-datasource`.
+- [x] 9.4 Refactor `manage-windows-datasource.yml` to call `scripts/manage-tdx-datasource.ps1`.
+- [x] 9.5 Add `scripts/run-tdx-runtime-smoke.ps1` that reuses deployed `mist-datasource\scripts\run-runtime-checks.ps1`.
+- [x] 9.6 Add retention cleanup for MySQL backup dumps and diagnostics snapshots under the Docker root.
+- [x] 9.7 Document local datasource operations, runtime smoke modes, and retention defaults in the Docker Windows runbook.
+- [ ] 9.8 Run OpenSpec validation, local PowerShell tests, and Windows workflow smoke for the changed deploy scripts.

--- a/openspec/changes/run-mist-mysql-in-docker/tasks.md
+++ b/openspec/changes/run-mist-mysql-in-docker/tasks.md
@@ -1,0 +1,69 @@
+## 1. Confirm Runtime Contract
+
+- [ ] 1.1 Decide whether MySQL persistence defaults to a Docker named volume or `E:\MistDocker\mysql-data` bind mount.
+- [ ] 1.2 Confirm default Docker root path, datasource root path, backup path, and diagnostics path.
+- [ ] 1.3 Confirm whether `chan-api` should be exposed on LAN port `8008` or host-local only in the first deployment.
+- [ ] 1.4 Define the first production health endpoint for `chan-api`.
+
+## 2. Prepare Mist Docker Runtime
+
+- [ ] 2.1 Update the Mist Docker image so it has a production default command for `apps/mist`.
+- [ ] 2.2 Add a supported container command for `apps/chan`.
+- [ ] 2.3 Remove development commands from the production Compose path.
+- [ ] 2.4 Verify the Docker image includes compiled outputs for both `dist/apps/mist/main.js` and `dist/apps/chan/main.js`.
+- [ ] 2.5 Add focused tests or script checks that validate production Docker entrypoints.
+
+## 3. Add Production Docker Compose Stack
+
+- [ ] 3.1 Add a production Compose file for `mysql`, `mist-backend`, and `chan-api`.
+- [ ] 3.2 Add a Docker environment template with image tag, MySQL credentials, ports, `DEFAULT_DATA_SOURCE=tdx`, and `TDX_BASE_URL=http://host.docker.internal:9001`.
+- [ ] 3.3 Configure MySQL persistence according to the decision from task 1.1.
+- [ ] 3.4 Add container restart policies suitable for the Windows API machine.
+- [ ] 3.5 Add a container-side datasource reachability probe for `host.docker.internal:9001`.
+
+## 4. Add Database Migration And Backup Flow
+
+- [ ] 4.1 Decide the migration runner shape: one-shot Compose service or deployment script applying bundled SQL.
+- [ ] 4.2 Package Mist database migrations with the Mist release path used by Docker deployment.
+- [ ] 4.3 Add a migration command that runs against the MySQL container and records applied migrations.
+- [ ] 4.4 Add a pre-migration backup command using `mysqldump` to the configured backup path.
+- [ ] 4.5 Ensure deployment fails fast and prints migration logs when migrations fail.
+- [ ] 4.6 Add restore documentation and a manual restore script for MySQL backups.
+
+## 5. Refactor mist-deploy For Hybrid Docker Deployment
+
+- [ ] 5.1 Add `DockerRoot` and `DatasourceRoot` configuration to the deploy workflow and scripts.
+- [ ] 5.2 Change the deploy flow from appliance zip extraction to Docker Compose pull/up orchestration.
+- [ ] 5.3 Preserve machine-local Docker `.env`, datasource `.env`, MySQL data, backups, and diagnostics.
+- [ ] 5.4 Keep datasource WinSW installation and update logic separate from normal Mist image deployments.
+- [ ] 5.5 Add explicit rollback support by restoring the previous Mist image tag and restarting Compose services.
+- [ ] 5.6 Update workflow tests for the new Docker deploy inputs and removed appliance zip assumptions.
+
+## 6. Add Hybrid Health Checks
+
+- [ ] 6.1 Add health checks for Docker Desktop availability and Docker Compose service status.
+- [ ] 6.2 Add MySQL container connectivity and schema initialization checks.
+- [ ] 6.3 Add `mist-backend` HTTP health checks on port `8001`.
+- [ ] 6.4 Add `chan-api` HTTP health checks on port `8008` or the selected exposure mode.
+- [ ] 6.5 Add datasource health checks using the same URL configured for containerized Mist services.
+- [ ] 6.6 Add Mac-side smoke guidance for `MIST_API_BASE_URL=http://<windows-lan-ip>:8001`.
+
+## 7. Add Diagnostics And Log Collection
+
+- [ ] 7.1 Add a diagnostics command that writes timestamped output under the Docker diagnostics path.
+- [ ] 7.2 Collect `docker compose ps` and recent Docker logs for MySQL, `mist-backend`, and `chan-api`.
+- [ ] 7.3 Collect datasource WinSW service status and recent datasource logs from `DatasourceRoot`.
+- [ ] 7.4 Collect health-check output and deployment metadata.
+- [ ] 7.5 Save a short diagnostic snapshot after every deployment success or failure.
+
+## 8. Documentation And Verification
+
+- [ ] 8.1 Document the hybrid topology and explain why datasource remains WinSW-managed.
+- [ ] 8.2 Document first-time setup for Docker Desktop, Docker root, datasource root, and local `.env` files.
+- [ ] 8.3 Document normal upgrade, rollback, backup, restore, and diagnostics procedures.
+- [ ] 8.4 Run OpenSpec validation for `run-mist-mysql-in-docker`.
+- [ ] 8.5 Run local script/parser tests for changed deployment scripts.
+- [ ] 8.6 Build and push a Mist Docker image containing `apps/mist` and `apps/chan`.
+- [ ] 8.7 Deploy on the Windows API machine with datasource WinSW already running.
+- [ ] 8.8 Verify container-to-host datasource connectivity from the Mist containers.
+- [ ] 8.9 Verify Mac can reach `http://<windows-lan-ip>:8001` and `http://<windows-lan-ip>:8008` when enabled.

--- a/openspec/changes/run-mist-mysql-in-docker/tasks.md
+++ b/openspec/changes/run-mist-mysql-in-docker/tasks.md
@@ -77,4 +77,4 @@
 - [x] 9.5 Add `scripts/run-tdx-runtime-smoke.ps1` that reuses deployed `mist-datasource\scripts\run-runtime-checks.ps1`.
 - [x] 9.6 Add retention cleanup for MySQL backup dumps and diagnostics snapshots under the Docker root.
 - [x] 9.7 Document local datasource operations, runtime smoke modes, and retention defaults in the Docker Windows runbook.
-- [ ] 9.8 Run OpenSpec validation, local PowerShell tests, and Windows workflow smoke for the changed deploy scripts.
+- [x] 9.8 Run OpenSpec validation, local PowerShell tests, and Windows workflow smoke for the changed deploy scripts.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "nest build",
     "build:docker": "nest build mist && nest build chan",
+    "db:migrate": "node tools/run-migrations.mjs",
     "format": "prettier --write \"apps/**/*.ts\" \"libs/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "build": "nest build",
+    "build:docker": "nest build mist && nest build chan",
     "format": "prettier --write \"apps/**/*.ts\" \"libs/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",

--- a/tools/run-migrations.mjs
+++ b/tools/run-migrations.mjs
@@ -1,0 +1,127 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const DEFAULT_MIGRATION_DIR = 'deploy/windows/database/migrations';
+
+export function loadMigrationConfig(env = process.env) {
+  const database = readRequiredEnv(env, 'mysql_server_database');
+  assertMysqlIdentifier(database, 'mysql_server_database');
+
+  return {
+    host: readRequiredEnv(env, 'mysql_server_host'),
+    port: parsePort(env.mysql_server_port || '3306'),
+    user: readRequiredEnv(env, 'mysql_server_username'),
+    password: readRequiredEnv(env, 'mysql_server_password'),
+    database,
+  };
+}
+
+export async function runMigrations({
+  env = process.env,
+  migrationDir = env.MIGRATION_DIR || join(process.cwd(), DEFAULT_MIGRATION_DIR),
+  mysqlModule,
+  logger = console,
+} = {}) {
+  const config = loadMigrationConfig(env);
+  const mysql = mysqlModule || (await import('mysql2/promise'));
+  const connection = await mysql.createConnection({
+    ...config,
+    multipleStatements: true,
+  });
+
+  try {
+    logger.log(`Run database migrations from ${migrationDir}`);
+    await ensureMigrationTable(connection);
+
+    const migrations = await listMigrationFiles(migrationDir);
+    if (migrations.length === 0) {
+      logger.warn(`No migration files found in ${migrationDir}`);
+      return;
+    }
+
+    for (const migration of migrations) {
+      const applied = await isMigrationApplied(connection, migration.name);
+      if (applied) {
+        logger.log(`Already applied ${migration.name}`);
+        continue;
+      }
+
+      logger.log(`Applying ${migration.name}`);
+      const sql = await readFile(migration.path, 'utf8');
+      await connection.query(sql);
+      await recordMigration(connection, migration.name);
+      logger.log(`Applied ${migration.name}`);
+    }
+  } finally {
+    await connection.end();
+  }
+}
+
+async function ensureMigrationTable(connection) {
+  await connection.execute(`
+CREATE TABLE IF NOT EXISTS \`schema_migrations\` (
+  \`version\` varchar(190) NOT NULL,
+  \`applied_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (\`version\`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+`);
+}
+
+async function listMigrationFiles(migrationDir) {
+  const entries = await readdir(migrationDir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.sql'))
+    .map((entry) => ({
+      name: entry.name,
+      path: join(migrationDir, entry.name),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+async function isMigrationApplied(connection, version) {
+  const [rows] = await connection.execute(
+    'SELECT COUNT(*) AS count FROM `schema_migrations` WHERE `version` = ?',
+    [version],
+  );
+  const first = Array.isArray(rows) ? rows[0] : undefined;
+  return Number(first?.count || 0) > 0;
+}
+
+async function recordMigration(connection, version) {
+  await connection.execute(
+    'INSERT INTO `schema_migrations` (`version`) VALUES (?)',
+    [version],
+  );
+}
+
+function readRequiredEnv(env, key) {
+  const value = env[key];
+  if (!value) {
+    throw new Error(`${key} is required`);
+  }
+  return value;
+}
+
+function parsePort(value) {
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`mysql_server_port must be a valid TCP port: ${value}`);
+  }
+  return port;
+}
+
+function assertMysqlIdentifier(value, label) {
+  if (!/^[A-Za-z0-9_]+$/.test(value)) {
+    throw new Error(
+      `${label} must contain only letters, numbers, and underscores: ${value}`,
+    );
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runMigrations().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/tools/test-docker-runtime.sh
+++ b/tools/test-docker-runtime.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_file() {
+  local path="$1"
+  [[ -f "$path" ]] || fail "missing file: $path"
+}
+
+assert_contains() {
+  local path="$1"
+  local expected="$2"
+  grep -Fq "$expected" "$path" || fail "missing expected text in $path: $expected"
+}
+
+assert_file Dockerfile
+assert_file docker-entrypoint.sh
+assert_file package.json
+assert_file dist/apps/mist/main.js
+assert_file dist/apps/chan/main.js
+
+assert_contains package.json '"build:docker": "nest build mist && nest build chan"'
+assert_contains Dockerfile 'RUN pnpm run build:docker'
+assert_contains Dockerfile 'COPY --from=builder /app/dist ./dist'
+assert_contains Dockerfile 'CMD ["node", "dist/apps/mist/main.js"]'
+assert_contains docker-entrypoint.sh 'exec "$@"'
+
+echo "Docker runtime contract checks passed."

--- a/tools/test-docker-runtime.sh
+++ b/tools/test-docker-runtime.sh
@@ -20,12 +20,17 @@ assert_contains() {
 assert_file Dockerfile
 assert_file docker-entrypoint.sh
 assert_file package.json
+assert_file tools/run-migrations.mjs
+assert_file deploy/windows/database/migrations/001_init_core_tables.sql
 assert_file dist/apps/mist/main.js
 assert_file dist/apps/chan/main.js
 
 assert_contains package.json '"build:docker": "nest build mist && nest build chan"'
+assert_contains package.json '"db:migrate": "node tools/run-migrations.mjs"'
 assert_contains Dockerfile 'RUN pnpm run build:docker'
 assert_contains Dockerfile 'COPY --from=builder /app/dist ./dist'
+assert_contains Dockerfile 'COPY --from=builder /app/tools ./tools'
+assert_contains Dockerfile 'COPY --from=builder /app/deploy/windows/database ./deploy/windows/database'
 assert_contains Dockerfile 'CMD ["node", "dist/apps/mist/main.js"]'
 assert_contains docker-entrypoint.sh 'exec "$@"'
 

--- a/tools/test-run-migrations.mjs
+++ b/tools/test-run-migrations.mjs
@@ -1,0 +1,191 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { runMigrations } from './run-migrations.mjs';
+
+const env = {
+  mysql_server_host: 'mysql',
+  mysql_server_port: '3306',
+  mysql_server_username: 'mist',
+  mysql_server_password: 'secret',
+  mysql_server_database: 'mist',
+};
+
+async function withMigrationDir(files, callback) {
+  const dir = mkdtempSync(join(tmpdir(), 'mist-migrations-'));
+  try {
+    for (const [name, sql] of Object.entries(files)) {
+      writeFileSync(join(dir, name), sql, 'utf8');
+    }
+    return await callback(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function createFakeMysql({ initiallyApplied = [], failOnSql = '' } = {}) {
+  const applied = new Set(initiallyApplied);
+  const appliedInsertions = [];
+  const migrationQueries = [];
+  const executeCalls = [];
+  let connectionOptions;
+  let ended = false;
+
+  const connection = {
+    async execute(sql, params = []) {
+      executeCalls.push({ sql, params });
+
+      if (sql.includes('SELECT COUNT(*)') && sql.includes('schema_migrations')) {
+        const version = params[0];
+        return [[{ count: applied.has(version) ? 1 : 0 }], []];
+      }
+
+      if (sql.includes('INSERT INTO `schema_migrations`')) {
+        const version = params[0];
+        applied.add(version);
+        appliedInsertions.push(version);
+        return [{ affectedRows: 1 }, []];
+      }
+
+      return [{ affectedRows: 0 }, []];
+    },
+
+    async query(sql) {
+      if (failOnSql && sql.includes(failOnSql)) {
+        throw new Error(`migration failed for ${failOnSql}`);
+      }
+      migrationQueries.push(sql);
+      return [{ affectedRows: 0 }, []];
+    },
+
+    async end() {
+      ended = true;
+    },
+  };
+
+  const mysqlModule = {
+    async createConnection(options) {
+      connectionOptions = options;
+      return connection;
+    },
+  };
+
+  return {
+    mysqlModule,
+    getState() {
+      return {
+        applied,
+        appliedInsertions,
+        connectionOptions,
+        ended,
+        executeCalls,
+        migrationQueries,
+      };
+    },
+  };
+}
+
+describe('runMigrations', () => {
+  it('applies SQL files in filename order and records applied versions', async () => {
+    await withMigrationDir(
+      {
+        '002_second.sql': 'SELECT 2;',
+        '001_first.sql': 'SELECT 1;',
+      },
+      async (migrationDir) => {
+        const fakeMysql = createFakeMysql();
+
+        await runMigrations({
+          env,
+          migrationDir,
+          mysqlModule: fakeMysql.mysqlModule,
+          logger: { log() {}, warn() {}, error() {} },
+        });
+
+        const state = fakeMysql.getState();
+        assert.equal(state.connectionOptions.host, 'mysql');
+        assert.equal(state.connectionOptions.port, 3306);
+        assert.equal(state.connectionOptions.user, 'mist');
+        assert.equal(state.connectionOptions.password, 'secret');
+        assert.equal(state.connectionOptions.database, 'mist');
+        assert.equal(state.connectionOptions.multipleStatements, true);
+        assert.deepEqual(state.migrationQueries, ['SELECT 1;', 'SELECT 2;']);
+        assert.deepEqual(state.appliedInsertions, [
+          '001_first.sql',
+          '002_second.sql',
+        ]);
+        assert.equal(state.ended, true);
+      },
+    );
+  });
+
+  it('skips migrations already recorded in schema_migrations', async () => {
+    await withMigrationDir(
+      {
+        '001_first.sql': 'SELECT 1;',
+        '002_second.sql': 'SELECT 2;',
+      },
+      async (migrationDir) => {
+        const fakeMysql = createFakeMysql({
+          initiallyApplied: ['001_first.sql'],
+        });
+
+        await runMigrations({
+          env,
+          migrationDir,
+          mysqlModule: fakeMysql.mysqlModule,
+          logger: { log() {}, warn() {}, error() {} },
+        });
+
+        const state = fakeMysql.getState();
+        assert.deepEqual(state.migrationQueries, ['SELECT 2;']);
+        assert.deepEqual(state.appliedInsertions, ['002_second.sql']);
+      },
+    );
+  });
+
+  it('does not record a migration version when SQL application fails', async () => {
+    await withMigrationDir(
+      {
+        '001_bad.sql': 'SELECT FAIL;',
+      },
+      async (migrationDir) => {
+        const fakeMysql = createFakeMysql({ failOnSql: 'FAIL' });
+
+        await assert.rejects(
+          () =>
+            runMigrations({
+              env,
+              migrationDir,
+              mysqlModule: fakeMysql.mysqlModule,
+              logger: { log() {}, warn() {}, error() {} },
+            }),
+          /migration failed for FAIL/,
+        );
+
+        const state = fakeMysql.getState();
+        assert.deepEqual(state.appliedInsertions, []);
+        assert.equal(state.ended, true);
+      },
+    );
+  });
+
+  it('rejects unsafe database names before connecting', async () => {
+    const fakeMysql = createFakeMysql();
+
+    await assert.rejects(
+      () =>
+        runMigrations({
+          env: { ...env, mysql_server_database: 'mist-prod' },
+          migrationDir: tmpdir(),
+          mysqlModule: fakeMysql.mysqlModule,
+          logger: { log() {}, warn() {}, error() {} },
+        }),
+      /mysql_server_database must contain only letters, numbers, and underscores/,
+    );
+
+    assert.equal(fakeMysql.getState().connectionOptions, undefined);
+  });
+});


### PR DESCRIPTION
Adds the production Docker runtime contract for apps/mist and apps/chan, bundles the migration runner, and documents the Windows hybrid Docker plus WinSW topology. Validation run locally: chan health Jest spec, migration runner test, Nest builds for mist and chan, Docker runtime script, Docker image build, and OpenSpec strict validation. The built GHCR image for this branch is ghcr.io/mist-trade/mist:893bb92fb655accae4b4460db2d3051eac5f269a.